### PR TITLE
Fix bug in NOC

### DIFF
--- a/src/main/java/com/github/mauricioaniche/ck/CK.java
+++ b/src/main/java/com/github/mauricioaniche/ck/CK.java
@@ -6,25 +6,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
+import com.github.mauricioaniche.ck.metric.*;
 import org.apache.log4j.Logger;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 
-import com.github.mauricioaniche.ck.metric.CBO;
-import com.github.mauricioaniche.ck.metric.DIT;
-import com.github.mauricioaniche.ck.metric.LCOM;
-import com.github.mauricioaniche.ck.metric.Metric;
-import com.github.mauricioaniche.ck.metric.NOC;
-import com.github.mauricioaniche.ck.metric.NOF;
-import com.github.mauricioaniche.ck.metric.NOM;
-import com.github.mauricioaniche.ck.metric.NOPF;
-import com.github.mauricioaniche.ck.metric.NOPM;
-import com.github.mauricioaniche.ck.metric.NOSF;
-import com.github.mauricioaniche.ck.metric.NOSI;
-import com.github.mauricioaniche.ck.metric.NOSM;
-import com.github.mauricioaniche.ck.metric.RFC;
-import com.github.mauricioaniche.ck.metric.WMC;
 import com.google.common.collect.Lists;
 
 public class CK {
@@ -46,11 +33,14 @@ public class CK {
 		}
 	}
 
-	public List<Callable<Metric>> pluggedMetrics; 
+    private final NOCExtras extras;
+
+    public List<Callable<Metric>> pluggedMetrics;
 	private static Logger log = Logger.getLogger(CK.class);
 
 	public CK() {
 		this.pluggedMetrics = new ArrayList<>();
+		this.extras = new NOCExtras();
 	}
 	
 	public CK plug(Callable<Metric> metric) {
@@ -83,8 +73,10 @@ public class CK {
 		}
 		
 		log.info("Finished parsing");
-		return storage.getReport();
-	}
+        CKReport report = storage.getReport();
+        extras.update(report);
+        return report;
+    }
 	
 	private List<Metric> metrics() {
 		List<Metric> all = defaultMetrics();
@@ -94,7 +86,7 @@ public class CK {
 	}
 
 	private List<Metric> defaultMetrics() {
-		return new ArrayList<>(Arrays.asList(new DIT(), new NOC(), new WMC(), new CBO(), new LCOM(), new RFC(), new NOM(),
+		return new ArrayList<>(Arrays.asList(new DIT(), new NOC(extras), new WMC(), new CBO(), new LCOM(), new RFC(), new NOM(),
 				new NOF(), new NOPF(), new NOSF(),
 				new NOPM(), new NOSM(), new NOSI()));
 	}

--- a/src/main/java/com/github/mauricioaniche/ck/CKNumber.java
+++ b/src/main/java/com/github/mauricioaniche/ck/CKNumber.java
@@ -83,7 +83,7 @@ public class CKNumber {
 	}
 
 	public void incNoc() {
-		this.noc++;
+		incNoc(1);
 	}
 	
 	public int getNoc() {
@@ -216,4 +216,7 @@ public class CKNumber {
 	}
 
 
+	public void incNoc (int value) {
+		this.noc += value;
+	}
 }

--- a/src/main/java/com/github/mauricioaniche/ck/metric/NOC.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/NOC.java
@@ -11,6 +11,11 @@ import com.github.mauricioaniche.ck.CKReport;
 public class NOC extends ASTVisitor implements Metric {
 
 	private CKReport report;
+	private NOCExtras extras;
+
+	public NOC(NOCExtras extras) {
+		this.extras = extras;
+	}
 
 	@Override
 	public boolean visit(TypeDeclaration node) {
@@ -19,6 +24,7 @@ public class NOC extends ASTVisitor implements Metric {
 		if(father!=null) {
 			CKNumber fatherCk = report.getByClassName(father.getBinaryName());
 			if(fatherCk!=null) fatherCk.incNoc();
+			else extras.plusOne(father.getBinaryName());
 		}
 
 		return false;

--- a/src/main/java/com/github/mauricioaniche/ck/metric/NOCExtras.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/NOCExtras.java
@@ -1,0 +1,33 @@
+package com.github.mauricioaniche.ck.metric;
+
+import com.github.mauricioaniche.ck.CKNumber;
+import com.github.mauricioaniche.ck.CKReport;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NOCExtras {
+
+    private Map<String, Integer> toAdd;
+
+    public NOCExtras() {
+        toAdd = new HashMap<>();
+    }
+
+    public void plusOne(String clazz) {
+        if(clazz.equals("java.lang.Object"))
+            return;
+
+        if(!toAdd.containsKey(clazz))
+            toAdd.put(clazz, 0);
+
+        toAdd.put(clazz, toAdd.get(clazz) + 1);
+    }
+
+    public void update(CKReport report) {
+        for(Map.Entry<String, Integer> kv : toAdd.entrySet()) {
+            CKNumber ck = report.getByClassName(kv.getKey());
+            if(ck!=null) ck.incNoc(kv.getValue());
+        }
+    }
+}


### PR DESCRIPTION
Fix bug that happened in NOC metric: sometimes the class wasn't on report, and thus, NOC++ was never happening. Now, we store 'extra plus ones' that should happen at the end in classes we did not find back then.

Fixes #5 and #6. Thanks @acapiluppi for reporting them.