### PR TITLE
Add support for Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11

--- a/README.md
+++ b/README.md
@@ -74,7 +74,36 @@ implementation.
 (In a previous version, it calculated NOC (Number of Children), but it doesn't do it anymore,
 as it requires too much memory.)
 
+# Java Syntax Support
+
+This tool uses Eclipse's JDT Core library under the hood for AST
+construction. Currently the compliance version is set to Java 11.
+
+Need support for a newer language version? The process of adding it is
+very straightforward, considering contributing a PR:
+
+1. Add a failing unit test case showcasing at least one of the syntax
+features present in the new version you want to provide support.
+2. Update the Eclipse JDT Core dependency in the `pom.xml` file. You may
+use a repository browser like
+[MVN Repository](https://mvnrepository.com/artifact/org.eclipse.jdt/org.eclipse.jdt.core)
+to ease this process.
+3. Also in the `pom.xml` file, update the `source` and `target`
+properties of the Maven Compiler plugin accordingly.
+4. Adjust the following lines in `CK.java`:
+    ```
+    [...]
+    ASTParser parser = ASTParser.newParser(AST.JLS11);
+    [...]
+    JavaCore.setComplianceOptions(JavaCore.VERSION_11, options);
+    [...]
+    ```
+5. Check if the failing unit test case you added in the first step is
+now green. Then submit a PR.
+
 # How to use the standalone version
+
+You need at least Java 11 to be able to compile and run this tool.
 
 To use the _latest version_ (which you should), clone the project and generate a JAR. A simple
 `mvn clean compile assembly:single` generates the single JAR file for you (see your _target_ folder).

--- a/fixtures/java11/Java11.java
+++ b/fixtures/java11/Java11.java
@@ -1,0 +1,15 @@
+package java11;
+
+import java.util.Function;
+
+class Java11 {
+
+	void m1() {
+		m2((@NotNull var n) -> n * 2);
+	}
+
+	void m2(Function<Integer, Integer> fn) {
+		System.out.println(fn.apply(2));
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.eclipse.jdt</groupId>
 			<artifactId>org.eclipse.jdt.core</artifactId>
-			<version>3.10.0</version>
+			<version>3.17.0</version>
 		</dependency>
 
 		<dependency>
@@ -106,10 +106,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.2</version>
+				<version>3.8.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 

--- a/src/main/java/com/github/mauricioaniche/ck/CK.java
+++ b/src/main/java/com/github/mauricioaniche/ck/CK.java
@@ -65,13 +65,13 @@ public class CK {
 
 		for(List<String> partition : partitions) {
 			log.debug("Next partition");
-			ASTParser parser = ASTParser.newParser(AST.JLS8);
+			ASTParser parser = ASTParser.newParser(AST.JLS11);
 			
 			parser.setResolveBindings(true);
 			parser.setBindingsRecovery(true);
 			
-			Map<?, ?> options = JavaCore.getOptions();
-			JavaCore.setComplianceOptions(JavaCore.VERSION_1_8, options);
+			Map<String, String> options = JavaCore.getOptions();
+			JavaCore.setComplianceOptions(JavaCore.VERSION_11, options);
 			parser.setCompilerOptions(options);
 			parser.setEnvironment(null, srcDirs, null, true);
 			parser.createASTs(partition.toArray(new String[partition.size()]), null, new String[0], storage, null);

--- a/src/main/java/com/github/mauricioaniche/ck/util/MetricsFinder.java
+++ b/src/main/java/com/github/mauricioaniche/ck/util/MetricsFinder.java
@@ -7,7 +7,6 @@ import org.reflections.Reflections;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class MetricsFinder {
 
@@ -22,7 +21,7 @@ public class MetricsFinder {
 		try {
 			ArrayList<MethodLevelMetric> metrics = new ArrayList<>();
 			for (Class<? extends MethodLevelMetric> aClass : methodLevelClasses) {
-				metrics.add(aClass.newInstance());
+				metrics.add(aClass.getDeclaredConstructor().newInstance());
 			}
 
 			return metrics;
@@ -49,7 +48,7 @@ public class MetricsFinder {
 		try {
 			ArrayList<ClassLevelMetric> metrics = new ArrayList<>();
 			for (Class<? extends ClassLevelMetric> aClass : classLevelClasses) {
-				metrics.add(aClass.newInstance());
+				metrics.add(aClass.getDeclaredConstructor().newInstance());
 			}
 
 			return metrics;

--- a/src/test/java/com/github/mauricioaniche/ck/metric/Java11SupportTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/metric/Java11SupportTest.java
@@ -1,0 +1,33 @@
+package com.github.mauricioaniche.ck.metric;
+
+import com.github.mauricioaniche.ck.CKClassResult;
+import com.github.mauricioaniche.ck.CKMethodResult;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Java11SupportTest extends BaseTest {
+
+	private static Map<String, CKClassResult> report;
+
+	@BeforeClass
+	public static void setUp() {
+		report = run(fixturesDir() + "/java11");
+	}
+
+	@Test
+	public void supportsJava11() {
+		assertTrue(this.report.containsKey("java11.Java11"));
+		CKClassResult clazz = this.report.get("java11.Java11");
+		Optional<CKMethodResult> maybeMethod = clazz.getMethod("m1/0");
+		assertTrue(maybeMethod.isPresent());
+		CKMethodResult method = maybeMethod.get();
+		assertEquals(1, method.getLambdasQty());
+	}
+
+}

--- a/src/test/java/com/github/mauricioaniche/ck/metric/ParameterCountTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/metric/ParameterCountTest.java
@@ -1,15 +1,11 @@
 package com.github.mauricioaniche.ck.metric;
 
-import com.github.mauricioaniche.ck.ASTDebugger;
 import com.github.mauricioaniche.ck.CKClassResult;
-import com.github.mauricioaniche.ck.CKMethodResult;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ParameterCountTest extends BaseTest{
 
@@ -24,38 +20,38 @@ public class ParameterCountTest extends BaseTest{
 	public void justDeclaration() {
 		CKClassResult a = report.get("pcount.A");
 		Map<String, Integer> variablesUsageA = a.getMethod("a/0").get().getVariablesUsage();
-		Assert.assertEquals(new Integer(0), variablesUsageA.get("a"));
-		Assert.assertEquals(new Integer(0), variablesUsageA.get("b"));
+		Assert.assertEquals(Integer.valueOf(0), variablesUsageA.get("a"));
+		Assert.assertEquals(Integer.valueOf(0), variablesUsageA.get("b"));
 	}
 
 	@Test
 	public void normalUse() {
 		CKClassResult a = report.get("pcount.A");
 		Map<String, Integer> variablesUsageA = a.getMethod("b/0").get().getVariablesUsage();
-		Assert.assertEquals(new Integer(4), variablesUsageA.get("a")); // a appears 5 times
-		Assert.assertEquals(new Integer(2), variablesUsageA.get("b"));
+		Assert.assertEquals(Integer.valueOf(4), variablesUsageA.get("a")); // a appears 5 times
+		Assert.assertEquals(Integer.valueOf(2), variablesUsageA.get("b"));
 	}
 
 	@Test
 	public void passingVariableToMethod() {
 		CKClassResult a = report.get("pcount.A");
 		Map<String, Integer> variablesUsageA = a.getMethod("bb/0").get().getVariablesUsage();
-		Assert.assertEquals(new Integer(1), variablesUsageA.get("a"));
+		Assert.assertEquals(Integer.valueOf(1), variablesUsageA.get("a"));
 	}
 
 	@Test
 	public void methodParameters() {
 		CKClassResult a = report.get("pcount.A");
 		Map<String, Integer> variablesUsageA = a.getMethod("c/1[int]").get().getVariablesUsage();
-		Assert.assertEquals(new Integer(0), variablesUsageA.get("a"));
+		Assert.assertEquals(Integer.valueOf(0), variablesUsageA.get("a"));
 
 		Map<String, Integer> variablesUsageB = a.getMethod("d/2[int,int]").get().getVariablesUsage();
-		Assert.assertEquals(new Integer(4), variablesUsageB.get("a"));
-		Assert.assertEquals(new Integer(0), variablesUsageB.get("b"));
+		Assert.assertEquals(Integer.valueOf(4), variablesUsageB.get("a"));
+		Assert.assertEquals(Integer.valueOf(0), variablesUsageB.get("b"));
 
 		Map<String, Integer> variablesUsageC = a.getMethod("e/2[pcount.B,int]").get().getVariablesUsage();
-		Assert.assertEquals(new Integer(2), variablesUsageC.get("a"));
-		Assert.assertEquals(new Integer(0), variablesUsageC.get("b"));
+		Assert.assertEquals(Integer.valueOf(2), variablesUsageC.get("a"));
+		Assert.assertEquals(Integer.valueOf(0), variablesUsageC.get("b"));
 
 	}
 


### PR DESCRIPTION
Note that this change also starts to require the usage of Java 11 for compiling and running the tool. Maybe this is worth a major version bump? What are your thoughts on this?

This is a follow up of our conversation here: #13.