### PR TITLE
Fix method signature resolution

### DIFF
--- a/fixtures/parameters/A.java
+++ b/fixtures/parameters/A.java
@@ -1,0 +1,8 @@
+import pac.B;
+import pac.Missing;
+import pacmissing.Missing2;
+
+class A {
+	void m1(B p1, pac.B p2, Missing p3, pac.Missing p4, Missing2 p5, pacmissing.Missing2 p6) {
+	}
+}

--- a/fixtures/parameters/pac/B.java
+++ b/fixtures/parameters/pac/B.java
@@ -1,0 +1,4 @@
+package pac;
+
+public class B {
+}

--- a/src/main/java/com/github/mauricioaniche/ck/util/JDTUtils.java
+++ b/src/main/java/com/github/mauricioaniche/ck/util/JDTUtils.java
@@ -23,7 +23,7 @@ public class JDTUtils {
 				ITypeBinding binding = parameter.getType().resolveBinding();
 
 				String v;
-				if(binding == null)
+				if(binding == null || binding.isRecovered())
 					v = parameter.getType().toString();
 				else
 					v = binding.getQualifiedName();

--- a/src/test/java/com/github/mauricioaniche/ck/metric/ParametersTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/metric/ParametersTest.java
@@ -1,0 +1,27 @@
+package com.github.mauricioaniche.ck.metric;
+
+import com.github.mauricioaniche.ck.CKClassResult;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+public class ParametersTest extends BaseTest {
+
+	private static Map<String, CKClassResult> report;
+
+	@BeforeClass
+	public static void setUp() {
+		report = run(fixturesDir() + "/parameters");
+	}
+
+	@Test
+	public void testSignatureResolution() {
+		assertTrue(this.report.containsKey("A"));
+		CKClassResult clazz = this.report.get("A");
+		assertTrue(clazz.getMethod("m1/6[pac.B,pac.B,Missing,pac.Missing,Missing2,pacmissing.Missing2]").isPresent());
+	}
+
+}


### PR DESCRIPTION
When an entire package is missing from the ClassPath, the current binding resolution fails to identify the parameter's type qualified name, returning only the first missing package's name, e.g:

> m1/6[pac.B,pac.B,Missing,pac.Missing,Missing2,pacmissing

Note that "pacmissing" is only the package name, the correct would be "pacmissing.Missing". This PR fixes this, by using the unresolved type name if the binding type is of the "recovered" type.

It would be even better to resolve as following:

> m1/6[pac.B,pac.B,Missing,pac.Missing,pacmissing.Missing2,pacmissing.Missing2

But I was unable to find a way to do it this way. The proposed change sounds better than the current resolution, though.