### PR TITLE
Use Apache commons-csv to write properly formatted CSV output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk11
+  - openjdk11 

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
 			<version>3.4</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-csv</artifactId>
+			<version>1.7</version>
+		</dependency>
 	</dependencies>
 
 	<distributionManagement>

--- a/src/main/java/com/github/mauricioaniche/ck/Runner.java
+++ b/src/main/java/com/github/mauricioaniche/ck/Runner.java
@@ -1,11 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Map;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
+import com.github.mauricioaniche.ck.util.ResultWriter;
 
 public class Runner {
 
@@ -17,125 +14,17 @@ public class Runner {
 		}
 
 		String path = args[0];
-
-		String[] classHeader = { "file", "class", "type", "cbo", "wmc", "dit", "rfc", "lcom", "totalMethods",
-				"staticMethods", "publicMethods", "privateMethods", "protectedMethods", "defaultMethods",
-				"abstractMethods", "finalMethods", "synchronizedMethods", "totalFields", "staticFields", "publicFields",
-				"privateFields", "protectedFields", "defaultFields", "finalFields", "synchronizedFields", "nosi", "loc",
-				"returnQty", "loopQty", "comparisonsQty", "tryCatchQty", "parenthesizedExpsQty", "stringLiteralsQty",
-				"numbersQty", "assignmentsQty", "mathOperationsQty", "variablesQty", "maxNestedBlocks",
-				"anonymousClassesQty", "subClassesQty", "lambdasQty", "uniqueWordsQty" };
-		String[] methodHeader = { "file", "class", "method", "line", "cbo", "wmc", "rfc", "loc", "returns", "variables",
-				"parameters", "startLine", "loopQty", "comparisonsQty", "tryCatchQty", "parenthesizedExpsQty",
-				"stringLiteralsQty", "numbersQty", "assignmentsQty", "mathOperationsQty", "maxNestedBlocks",
-				"anonymousClassesQty", "subClassesQty", "lambdasQty", "uniqueWordsQty" };
-		String[] varFieldHeader = { "file", "class", "method", "variable", "usage" };
 		
-		FileWriter classOut = new FileWriter("class.csv");
-		CSVPrinter classPrinter = new CSVPrinter(classOut, CSVFormat.DEFAULT.withHeader(classHeader));
-		FileWriter methodOut = new FileWriter("method.csv");
-		CSVPrinter methodPrinter = new CSVPrinter(methodOut, CSVFormat.DEFAULT.withHeader(methodHeader));
-		FileWriter variableOut = new FileWriter("variable.csv");
-		CSVPrinter variablePrinter = new CSVPrinter(variableOut, CSVFormat.DEFAULT.withHeader(varFieldHeader));
-		FileWriter fieldOut = new FileWriter("field.csv");
-		CSVPrinter fieldPrinter = new CSVPrinter(fieldOut, CSVFormat.DEFAULT.withHeader(varFieldHeader));
+		ResultWriter writer = new ResultWriter("class.csv", "method.csv", "variable.csv", "field.csv");
 		
 		new CK().calculate(path, result -> {
 			try {
-				classPrinter.printRecord(
-						result.getFile(),
-						result.getClassName(),
-						result.getType(),
-						result.getCbo(),
-						result.getWmc(),
-						result.getDit(),
-						result.getRfc(),
-						result.getLcom(),
-						result.getNumberOfMethods(),
-						result.getNumberOfStaticMethods(),
-						result.getNumberOfPublicMethods(),
-						result.getNumberOfPrivateMethods(),
-						result.getNumberOfProtectedMethods(),
-						result.getNumberOfDefaultMethods(),
-						result.getNumberOfAbstractMethods(),
-						result.getNumberOfFinalMethods(),
-						result.getNumberOfSynchronizedMethods(),
-						result.getNumberOfFields(),
-						result.getNumberOfStaticFields(),
-						result.getNumberOfPublicFields(),
-						result.getNumberOfPrivateFields(),
-						result.getNumberOfProtectedFields(),
-						result.getNumberOfDefaultFields(),
-						result.getNumberOfFinalFields(),
-						result.getNumberOfSynchronizedFields(),
-						result.getNosi(),
-						result.getLoc(),
-						result.getReturnQty(),
-						result.getLoopQty(),
-						result.getComparisonsQty(),
-						result.getTryCatchQty(),
-						result.getParenthesizedExpsQty(),
-						result.getStringLiteralsQty(),
-						result.getNumbersQty(),
-						result.getAssignmentsQty(),
-						result.getMathOperationsQty(),
-						result.getVariablesQty(),
-						result.getMaxNestedBlocks(),
-						result.getAnonymousClassesQty(),
-						result.getSubClassesQty(),
-						result.getLambdasQty(),
-						result.getUniqueWordsQty());
-
-				for (CKMethodResult method : result.getMethods()) {
-					methodPrinter.printRecord(
-							result.getFile(), 
-							result.getClassName(), 
-							method.getMethodName(),
-							method.getStartLine(),
-							method.getCbo(),
-							method.getWmc(),
-							method.getRfc(),
-							method.getLoc(),
-							method.getReturnQty(),
-							method.getVariablesQty(),
-							method.getParametersQty(),
-							method.getStartLine(),
-							method.getLoopQty(),
-							method.getComparisonsQty(),
-							method.getTryCatchQty(),
-							method.getParenthesizedExpsQty(),
-							method.getStringLiteralsQty(),
-							method.getNumbersQty(),
-							method.getAssignmentsQty(),
-							method.getMathOperationsQty(),
-							method.getMaxNestedBlocks(),
-							method.getAnonymousClassesQty(),
-							method.getSubClassesQty(),
-							method.getLambdasQty(),
-							method.getUniqueWordsQty());
-
-					for (Map.Entry<String, Integer> entry : method.getVariablesUsage().entrySet()) {
-						variablePrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
-								entry.getKey(), entry.getValue());
-					}
-
-					for (Map.Entry<String, Integer> entry : method.getFieldUsage().entrySet()) {
-						fieldPrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
-								entry.getKey(), entry.getValue());
-					}
-				}
+			    writer.printResult(result);
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
 		});
 		
-		classPrinter.flush();
-		classPrinter.close();
-		methodPrinter.flush();
-		methodPrinter.close();
-		variablePrinter.flush();
-		variablePrinter.close();
-		fieldPrinter.flush();
-		fieldPrinter.close();
+		writer.flushAndClose();
 	}
 }

--- a/src/main/java/com/github/mauricioaniche/ck/Runner.java
+++ b/src/main/java/com/github/mauricioaniche/ck/Runner.java
@@ -1,143 +1,93 @@
 package com.github.mauricioaniche.ck;
 
-import java.io.FileNotFoundException;
-import java.io.PrintStream;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.Map;
-import java.util.Set;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 
 public class Runner {
 
-	public static void main(String[] args) throws FileNotFoundException {
-		
-		if(args==null || args.length != 1) {
+	public static void main(String[] args) {
+
+		if (args == null || args.length != 1) {
 			System.out.println("Usage java -jar ck.jar <path to project>");
 			System.exit(1);
 		}
-		
+
 		String path = args[0];
 
-		PrintStream classOutput = new PrintStream("class.csv");
-		classOutput.println("file,class,type,cbo,wmc,dit,rfc,lcom,totalMethods,staticMethods,publicMethods,privateMethods,protectedMethods," +
-				"defaultMethods,abstractMethods,finalMethods,synchronizedMethods,totalFields,staticFields,publicFields,privateFields," +
-				"protectedFields,defaultFields,finalFields,synchronizedFields,nosi,loc,returnQty,loopQty,comparisonsQty," +
-				"tryCatchQty,parenthesizedExpsQty,stringLiteralsQty,numbersQty,assignmentsQty,mathOperationsQty,variablesQty," +
-				"maxNestedBlocks,anonymousClassesQty,subClassesQty,lambdasQty,uniqueWordsQty");
-
-		PrintStream methodOutput = new PrintStream("method.csv");
-		methodOutput.println("file,class,method,line,cbo,wmc,rfc,loc,returns,variables,parameters,startLine," +
-				"loopQty,comparisonsQty,tryCatchQty,parenthesizedExpsQty,stringLiteralsQty,numbersQty,assignmentsQty," +
-				"mathOperationsQty,maxNestedBlocks,anonymousClassesQty,subClassesQty,lambdasQty,uniqueWordsQty");
-
-		PrintStream variableOutput = new PrintStream("variable.csv");
-		variableOutput.println("file,class,method,variable,usage");
-
-		PrintStream fieldOutput = new PrintStream("field.csv");
-		fieldOutput.println("file,class,method,variable,usage");
-
 		new CK().calculate(path, result -> {
-			if(result.isError()) return;
+			try {
+				writeResults(result);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		});
+	}
 
-			classOutput.println(
-				result.getFile() + "," +
-				result.getClassName() + "," +
-				result.getType() + "," +
-				result.getCbo() + "," +
-				result.getWmc() + "," +
-				result.getDit() + "," +
-				result.getRfc() + "," +
-				result.getLcom() + "," +
-				result.getNumberOfMethods() + "," +
-				result.getNumberOfStaticMethods() + "," +
-				result.getNumberOfPublicMethods() + "," +
-				result.getNumberOfPrivateMethods() + "," +
-				result.getNumberOfProtectedMethods() + "," +
-				result.getNumberOfDefaultMethods() + "," +
-				result.getNumberOfAbstractMethods() + "," +
-				result.getNumberOfFinalMethods() + "," +
-				result.getNumberOfSynchronizedMethods() + "," +
-				result.getNumberOfFields() + "," +
-				result.getNumberOfStaticFields() + "," +
-				result.getNumberOfPublicFields() + "," +
-				result.getNumberOfPrivateFields() + "," +
-				result.getNumberOfProtectedFields() + "," +
-				result.getNumberOfDefaultFields() + "," +
-				result.getNumberOfFinalFields() + "," +
-				result.getNumberOfSynchronizedFields() + "," +
-				result.getNosi() + "," +
-				result.getLoc() + "," +
-				result.getReturnQty() + "," +
-				result.getLoopQty() + "," +
-				result.getComparisonsQty() + "," +
-				result.getTryCatchQty() + "," +
-				result.getParenthesizedExpsQty() + "," +
-				result.getStringLiteralsQty() + "," +
-				result.getNumbersQty() + "," +
-				result.getAssignmentsQty() + "," +
-				result.getMathOperationsQty() + "," +
-				result.getMathOperationsQty() + "," +
-				result.getVariablesQty() + "," +
-				result.getMaxNestedBlocks() + "," +
-				result.getAnonymousClassesQty() + "," +
-				result.getSubClassesQty() + "," +
-				result.getLambdasQty() + "," +
-				result.getUniqueWordsQty()
-			);
+	public static void writeResults(CKClassResult result) throws IOException {
+		if (result.isError())
+			return;
 
-			for(CKMethodResult method : result.getMethods()) {
-				methodOutput.println(
-					result.getFile() + "," +
-					result.getClassName() + "," +
-					method.getMethodName() + "," +
-					method.getStartLine() + "," +
-					method.getCbo() + "," +
-					method.getWmc() + "," +
-					method.getRfc() + "," +
-					method.getLoc() + "," +
-					method.getReturnQty() + "," +
-					method.getVariablesQty() + "," +
-					method.getParametersQty()  + "," +
-					method.getStartLine() + "," +
-					method.getLoopQty() + "," +
-					method.getComparisonsQty() + "," +
-					method.getTryCatchQty() + "," +
-					method.getParenthesizedExpsQty() + "," +
-					method.getStringLiteralsQty() + "," +
-					method.getNumbersQty() + "," +
-					method.getAssignmentsQty() + "," +
-					method.getMathOperationsQty() + "," +
-					method.getMaxNestedBlocks() + "," +
-					method.getAnonymousClassesQty() + "," +
-					method.getSubClassesQty() + "," +
-					method.getLambdasQty() + "," +
-					method.getUniqueWordsQty()
-				);
+		String[] classHeader = { "file", "class", "type", "cbo", "wmc", "dit", "rfc", "lcom", "totalMethods",
+				"staticMethods", "publicMethods", "privateMethods", "protectedMethods", "defaultMethods",
+				"abstractMethods", "finalMethods", "synchronizedMethods", "totalFields", "staticFields", "publicFields",
+				"privateFields", "protectedFields", "defaultFields", "finalFields", "synchronizedFields", "nosi", "loc",
+				"returnQty", "loopQty", "comparisonsQty", "tryCatchQty", "parenthesizedExpsQty", "stringLiteralsQty",
+				"numbersQty", "assignmentsQty", "mathOperationsQty", "variablesQty", "maxNestedBlocks",
+				"anonymousClassesQty", "subClassesQty", "lambdasQty", "uniqueWordsQty" };
+		String[] methodHeader = { "file", "class", "method", "line", "cbo", "wmc", "rfc", "loc", "returns", "variables",
+				"parameters", "startLine", "loopQty", "comparisonsQty", "tryCatchQty", "parenthesizedExpsQty",
+				"stringLiteralsQty", "numbersQty", "assignmentsQty", "mathOperationsQty", "maxNestedBlocks",
+				"anonymousClassesQty", "subClassesQty", "lambdasQty", "uniqueWordsQty" };
+		String[] varFieldHeader = { "file", "class", "method", "variable", "usage" };
 
-				for(Map.Entry<String,Integer> entry : method.getVariablesUsage().entrySet()) {
+		try (FileWriter classOutput = new FileWriter("class.csv");
+				CSVPrinter classPrinter = new CSVPrinter(classOutput, CSVFormat.DEFAULT.withHeader(classHeader));
+				FileWriter methodOut = new FileWriter("method.csv");
+				CSVPrinter methodPrinter = new CSVPrinter(methodOut, CSVFormat.DEFAULT.withHeader(methodHeader));
+				FileWriter variableOut = new FileWriter("variable.csv");
+				CSVPrinter variablePrinter = new CSVPrinter(variableOut, CSVFormat.DEFAULT.withHeader(varFieldHeader));
+				FileWriter fieldOut = new FileWriter("field.csv");
+				CSVPrinter fieldPrinter = new CSVPrinter(fieldOut, CSVFormat.DEFAULT.withHeader(varFieldHeader))) {
+			classPrinter.printRecord(result.getFile(), result.getClassName(), result.getType(), result.getCbo(),
+					result.getWmc(), result.getDit(), result.getRfc(), result.getLcom(), result.getNumberOfMethods(),
+					result.getNumberOfStaticMethods(), result.getNumberOfPublicMethods(),
+					result.getNumberOfPrivateMethods(), result.getNumberOfProtectedMethods(),
+					result.getNumberOfDefaultMethods(), result.getNumberOfAbstractMethods(),
+					result.getNumberOfFinalMethods(), result.getNumberOfSynchronizedMethods(),
+					result.getNumberOfFields(), result.getNumberOfStaticFields(), result.getNumberOfPublicFields(),
+					result.getNumberOfPrivateFields(), result.getNumberOfProtectedFields(),
+					result.getNumberOfDefaultFields(), result.getNumberOfFinalFields(),
+					result.getNumberOfSynchronizedFields(), result.getNosi(), result.getLoc(), result.getReturnQty(),
+					result.getLoopQty(), result.getComparisonsQty(), result.getTryCatchQty(),
+					result.getParenthesizedExpsQty(), result.getStringLiteralsQty(), result.getNumbersQty(),
+					result.getAssignmentsQty(), result.getMathOperationsQty(), result.getVariablesQty(),
+					result.getMaxNestedBlocks(), result.getAnonymousClassesQty(), result.getSubClassesQty(),
+					result.getLambdasQty(), result.getUniqueWordsQty());
 
-					variableOutput.println(
-						result.getFile() + "," +
-						result.getClassName() + "," +
-						method.getMethodName() + "," +
-						entry.getKey() + "," + entry.getValue());
+			for (CKMethodResult method : result.getMethods()) {
+				methodPrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
+						method.getStartLine(), method.getCbo(), method.getWmc(), method.getRfc(), method.getLoc(),
+						method.getReturnQty(), method.getVariablesQty(), method.getParametersQty(),
+						method.getStartLine(), method.getLoopQty(), method.getComparisonsQty(), method.getTryCatchQty(),
+						method.getParenthesizedExpsQty(), method.getStringLiteralsQty(), method.getNumbersQty(),
+						method.getAssignmentsQty(), method.getMathOperationsQty(), method.getMaxNestedBlocks(),
+						method.getAnonymousClassesQty(), method.getSubClassesQty(), method.getLambdasQty(),
+						method.getUniqueWordsQty());
+
+				for (Map.Entry<String, Integer> entry : method.getVariablesUsage().entrySet()) {
+					variablePrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
+							entry.getKey(), entry.getValue());
 				}
 
-				for(Map.Entry<String,Integer> entry : method.getFieldUsage().entrySet()) {
-
-					fieldOutput.println(
-						result.getFile() + "," +
-						result.getClassName() + "," +
-						method.getMethodName() + "," +
-						entry.getKey() + "," + entry.getValue());
+				for (Map.Entry<String, Integer> entry : method.getFieldUsage().entrySet()) {
+					fieldPrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
+							entry.getKey(), entry.getValue());
 				}
 			}
-
-
-		});
-		
-		classOutput.close();
-		methodOutput.close();
-		variableOutput.close();
-		fieldOutput.close();
-		
+		}
 	}
 }

--- a/src/main/java/com/github/mauricioaniche/ck/Runner.java
+++ b/src/main/java/com/github/mauricioaniche/ck/Runner.java
@@ -9,7 +9,7 @@ import org.apache.commons.csv.CSVPrinter;
 
 public class Runner {
 
-	public static void main(String[] args) {
+	public static void main(String[] args) throws IOException {
 
 		if (args == null || args.length != 1) {
 			System.out.println("Usage java -jar ck.jar <path to project>");
@@ -17,19 +17,6 @@ public class Runner {
 		}
 
 		String path = args[0];
-
-		new CK().calculate(path, result -> {
-			try {
-				writeResults(result);
-			} catch (IOException e) {
-				throw new RuntimeException(e);
-			}
-		});
-	}
-
-	public static void writeResults(CKClassResult result) throws IOException {
-		if (result.isError())
-			return;
 
 		String[] classHeader = { "file", "class", "type", "cbo", "wmc", "dit", "rfc", "lcom", "totalMethods",
 				"staticMethods", "publicMethods", "privateMethods", "protectedMethods", "defaultMethods",
@@ -43,51 +30,112 @@ public class Runner {
 				"stringLiteralsQty", "numbersQty", "assignmentsQty", "mathOperationsQty", "maxNestedBlocks",
 				"anonymousClassesQty", "subClassesQty", "lambdasQty", "uniqueWordsQty" };
 		String[] varFieldHeader = { "file", "class", "method", "variable", "usage" };
+		
+		FileWriter classOut = new FileWriter("class.csv");
+		CSVPrinter classPrinter = new CSVPrinter(classOut, CSVFormat.DEFAULT.withHeader(classHeader));
+		FileWriter methodOut = new FileWriter("method.csv");
+		CSVPrinter methodPrinter = new CSVPrinter(methodOut, CSVFormat.DEFAULT.withHeader(methodHeader));
+		FileWriter variableOut = new FileWriter("variable.csv");
+		CSVPrinter variablePrinter = new CSVPrinter(variableOut, CSVFormat.DEFAULT.withHeader(varFieldHeader));
+		FileWriter fieldOut = new FileWriter("field.csv");
+		CSVPrinter fieldPrinter = new CSVPrinter(fieldOut, CSVFormat.DEFAULT.withHeader(varFieldHeader));
+		
+		new CK().calculate(path, result -> {
+			try {
+				classPrinter.printRecord(
+						result.getFile(),
+						result.getClassName(),
+						result.getType(),
+						result.getCbo(),
+						result.getWmc(),
+						result.getDit(),
+						result.getRfc(),
+						result.getLcom(),
+						result.getNumberOfMethods(),
+						result.getNumberOfStaticMethods(),
+						result.getNumberOfPublicMethods(),
+						result.getNumberOfPrivateMethods(),
+						result.getNumberOfProtectedMethods(),
+						result.getNumberOfDefaultMethods(),
+						result.getNumberOfAbstractMethods(),
+						result.getNumberOfFinalMethods(),
+						result.getNumberOfSynchronizedMethods(),
+						result.getNumberOfFields(),
+						result.getNumberOfStaticFields(),
+						result.getNumberOfPublicFields(),
+						result.getNumberOfPrivateFields(),
+						result.getNumberOfProtectedFields(),
+						result.getNumberOfDefaultFields(),
+						result.getNumberOfFinalFields(),
+						result.getNumberOfSynchronizedFields(),
+						result.getNosi(),
+						result.getLoc(),
+						result.getReturnQty(),
+						result.getLoopQty(),
+						result.getComparisonsQty(),
+						result.getTryCatchQty(),
+						result.getParenthesizedExpsQty(),
+						result.getStringLiteralsQty(),
+						result.getNumbersQty(),
+						result.getAssignmentsQty(),
+						result.getMathOperationsQty(),
+						result.getVariablesQty(),
+						result.getMaxNestedBlocks(),
+						result.getAnonymousClassesQty(),
+						result.getSubClassesQty(),
+						result.getLambdasQty(),
+						result.getUniqueWordsQty());
 
-		try (FileWriter classOutput = new FileWriter("class.csv");
-				CSVPrinter classPrinter = new CSVPrinter(classOutput, CSVFormat.DEFAULT.withHeader(classHeader));
-				FileWriter methodOut = new FileWriter("method.csv");
-				CSVPrinter methodPrinter = new CSVPrinter(methodOut, CSVFormat.DEFAULT.withHeader(methodHeader));
-				FileWriter variableOut = new FileWriter("variable.csv");
-				CSVPrinter variablePrinter = new CSVPrinter(variableOut, CSVFormat.DEFAULT.withHeader(varFieldHeader));
-				FileWriter fieldOut = new FileWriter("field.csv");
-				CSVPrinter fieldPrinter = new CSVPrinter(fieldOut, CSVFormat.DEFAULT.withHeader(varFieldHeader))) {
-			classPrinter.printRecord(result.getFile(), result.getClassName(), result.getType(), result.getCbo(),
-					result.getWmc(), result.getDit(), result.getRfc(), result.getLcom(), result.getNumberOfMethods(),
-					result.getNumberOfStaticMethods(), result.getNumberOfPublicMethods(),
-					result.getNumberOfPrivateMethods(), result.getNumberOfProtectedMethods(),
-					result.getNumberOfDefaultMethods(), result.getNumberOfAbstractMethods(),
-					result.getNumberOfFinalMethods(), result.getNumberOfSynchronizedMethods(),
-					result.getNumberOfFields(), result.getNumberOfStaticFields(), result.getNumberOfPublicFields(),
-					result.getNumberOfPrivateFields(), result.getNumberOfProtectedFields(),
-					result.getNumberOfDefaultFields(), result.getNumberOfFinalFields(),
-					result.getNumberOfSynchronizedFields(), result.getNosi(), result.getLoc(), result.getReturnQty(),
-					result.getLoopQty(), result.getComparisonsQty(), result.getTryCatchQty(),
-					result.getParenthesizedExpsQty(), result.getStringLiteralsQty(), result.getNumbersQty(),
-					result.getAssignmentsQty(), result.getMathOperationsQty(), result.getVariablesQty(),
-					result.getMaxNestedBlocks(), result.getAnonymousClassesQty(), result.getSubClassesQty(),
-					result.getLambdasQty(), result.getUniqueWordsQty());
+				for (CKMethodResult method : result.getMethods()) {
+					methodPrinter.printRecord(
+							result.getFile(), 
+							result.getClassName(), 
+							method.getMethodName(),
+							method.getStartLine(),
+							method.getCbo(),
+							method.getWmc(),
+							method.getRfc(),
+							method.getLoc(),
+							method.getReturnQty(),
+							method.getVariablesQty(),
+							method.getParametersQty(),
+							method.getStartLine(),
+							method.getLoopQty(),
+							method.getComparisonsQty(),
+							method.getTryCatchQty(),
+							method.getParenthesizedExpsQty(),
+							method.getStringLiteralsQty(),
+							method.getNumbersQty(),
+							method.getAssignmentsQty(),
+							method.getMathOperationsQty(),
+							method.getMaxNestedBlocks(),
+							method.getAnonymousClassesQty(),
+							method.getSubClassesQty(),
+							method.getLambdasQty(),
+							method.getUniqueWordsQty());
 
-			for (CKMethodResult method : result.getMethods()) {
-				methodPrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
-						method.getStartLine(), method.getCbo(), method.getWmc(), method.getRfc(), method.getLoc(),
-						method.getReturnQty(), method.getVariablesQty(), method.getParametersQty(),
-						method.getStartLine(), method.getLoopQty(), method.getComparisonsQty(), method.getTryCatchQty(),
-						method.getParenthesizedExpsQty(), method.getStringLiteralsQty(), method.getNumbersQty(),
-						method.getAssignmentsQty(), method.getMathOperationsQty(), method.getMaxNestedBlocks(),
-						method.getAnonymousClassesQty(), method.getSubClassesQty(), method.getLambdasQty(),
-						method.getUniqueWordsQty());
+					for (Map.Entry<String, Integer> entry : method.getVariablesUsage().entrySet()) {
+						variablePrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
+								entry.getKey(), entry.getValue());
+					}
 
-				for (Map.Entry<String, Integer> entry : method.getVariablesUsage().entrySet()) {
-					variablePrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
-							entry.getKey(), entry.getValue());
+					for (Map.Entry<String, Integer> entry : method.getFieldUsage().entrySet()) {
+						fieldPrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
+								entry.getKey(), entry.getValue());
+					}
 				}
-
-				for (Map.Entry<String, Integer> entry : method.getFieldUsage().entrySet()) {
-					fieldPrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
-							entry.getKey(), entry.getValue());
-				}
+			} catch (IOException e) {
+				throw new RuntimeException(e);
 			}
-		}
+		});
+		
+		classPrinter.flush();
+		classPrinter.close();
+		methodPrinter.flush();
+		methodPrinter.close();
+		variablePrinter.flush();
+		variablePrinter.close();
+		fieldPrinter.flush();
+		fieldPrinter.close();
 	}
 }

--- a/src/main/java/com/github/mauricioaniche/ck/util/ResultWriter.java
+++ b/src/main/java/com/github/mauricioaniche/ck/util/ResultWriter.java
@@ -1,0 +1,119 @@
+package com.github.mauricioaniche.ck.util;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+
+import com.github.mauricioaniche.ck.CKClassResult;
+import com.github.mauricioaniche.ck.CKMethodResult;
+
+public class ResultWriter {
+
+    private static final String[] CLASS_HEADER = { "file", "class", "type", "cbo", "wmc", "dit", "rfc", "lcom",
+            "totalMethods", "staticMethods", "publicMethods", "privateMethods", "protectedMethods", "defaultMethods",
+            "abstractMethods", "finalMethods", "synchronizedMethods", "totalFields", "staticFields", "publicFields",
+            "privateFields", "protectedFields", "defaultFields", "finalFields", "synchronizedFields", "nosi", "loc",
+            "returnQty", "loopQty", "comparisonsQty", "tryCatchQty", "parenthesizedExpsQty", "stringLiteralsQty",
+            "numbersQty", "assignmentsQty", "mathOperationsQty", "variablesQty", "maxNestedBlocks",
+            "anonymousClassesQty", "subClassesQty", "lambdasQty", "uniqueWordsQty" };
+    private static final String[] METHOD_HEADER = { "file", "class", "method", "line", "cbo", "wmc", "rfc", "loc",
+            "returns", "variables", "parameters", "startLine", "loopQty", "comparisonsQty", "tryCatchQty",
+            "parenthesizedExpsQty", "stringLiteralsQty", "numbersQty", "assignmentsQty", "mathOperationsQty",
+            "maxNestedBlocks", "anonymousClassesQty", "subClassesQty", "lambdasQty", "uniqueWordsQty" };
+    private static final String[] VAR_FIELD_HEADER = { "file", "class", "method", "variable", "usage" };
+
+    private CSVPrinter classPrinter;
+    private CSVPrinter methodPrinter;
+    private CSVPrinter variablePrinter;
+    private CSVPrinter fieldPrinter;
+
+    /**
+     * Initialise a new ResultWriter that writes to the specified files. Begins by
+     * writing CSV headers to each file.
+     * 
+     * @param classFile    Output file for class metrics
+     * @param methodFile   Output file for method metrics
+     * @param variableFile Output file for variable metrics
+     * @param fieldFile    Output file for field metrics
+     * @throws IOException If headers cannot be written
+     */
+    public ResultWriter(String classFile, String methodFile, String variableFile, String fieldFile) throws IOException {
+        FileWriter classOut = new FileWriter(classFile);
+        this.classPrinter = new CSVPrinter(classOut, CSVFormat.DEFAULT.withHeader(CLASS_HEADER));
+        FileWriter methodOut = new FileWriter(methodFile);
+        this.methodPrinter = new CSVPrinter(methodOut, CSVFormat.DEFAULT.withHeader(METHOD_HEADER));
+        FileWriter variableOut = new FileWriter(variableFile);
+        this.variablePrinter = new CSVPrinter(variableOut, CSVFormat.DEFAULT.withHeader(VAR_FIELD_HEADER));
+        FileWriter fieldOut = new FileWriter(fieldFile);
+        this.fieldPrinter = new CSVPrinter(fieldOut, CSVFormat.DEFAULT.withHeader(VAR_FIELD_HEADER));
+    }
+
+    /**
+     * Print results for a single class and its methods and fields to the
+     * appropriate CSVPrinters.
+     * 
+     * @param result The CKClassResult
+     * @throws IOException If output files cannot be written to
+     */
+    public void printResult(CKClassResult result) throws IOException {
+        if (result.isError()) {
+            return;
+        }
+
+        this.classPrinter.printRecord(result.getFile(), result.getClassName(), result.getType(), result.getCbo(),
+                result.getWmc(), result.getDit(), result.getRfc(), result.getLcom(), result.getNumberOfMethods(),
+                result.getNumberOfStaticMethods(), result.getNumberOfPublicMethods(),
+                result.getNumberOfPrivateMethods(), result.getNumberOfProtectedMethods(),
+                result.getNumberOfDefaultMethods(), result.getNumberOfAbstractMethods(),
+                result.getNumberOfFinalMethods(), result.getNumberOfSynchronizedMethods(), result.getNumberOfFields(),
+                result.getNumberOfStaticFields(), result.getNumberOfPublicFields(), result.getNumberOfPrivateFields(),
+                result.getNumberOfProtectedFields(), result.getNumberOfDefaultFields(), result.getNumberOfFinalFields(),
+                result.getNumberOfSynchronizedFields(), result.getNosi(), result.getLoc(), result.getReturnQty(),
+                result.getLoopQty(), result.getComparisonsQty(), result.getTryCatchQty(),
+                result.getParenthesizedExpsQty(), result.getStringLiteralsQty(), result.getNumbersQty(),
+                result.getAssignmentsQty(), result.getMathOperationsQty(), result.getVariablesQty(),
+                result.getMaxNestedBlocks(), result.getAnonymousClassesQty(), result.getSubClassesQty(),
+                result.getLambdasQty(), result.getUniqueWordsQty());
+
+        for (CKMethodResult method : result.getMethods()) {
+            this.methodPrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
+                    method.getStartLine(), method.getCbo(), method.getWmc(), method.getRfc(), method.getLoc(),
+                    method.getReturnQty(), method.getVariablesQty(), method.getParametersQty(), method.getStartLine(),
+                    method.getLoopQty(), method.getComparisonsQty(), method.getTryCatchQty(),
+                    method.getParenthesizedExpsQty(), method.getStringLiteralsQty(), method.getNumbersQty(),
+                    method.getAssignmentsQty(), method.getMathOperationsQty(), method.getMaxNestedBlocks(),
+                    method.getAnonymousClassesQty(), method.getSubClassesQty(), method.getLambdasQty(),
+                    method.getUniqueWordsQty());
+
+            for (Map.Entry<String, Integer> entry : method.getVariablesUsage().entrySet()) {
+                this.variablePrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
+                        entry.getKey(), entry.getValue());
+            }
+
+            for (Map.Entry<String, Integer> entry : method.getFieldUsage().entrySet()) {
+                this.fieldPrinter.printRecord(result.getFile(), result.getClassName(), method.getMethodName(),
+                        entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    /**
+     * Flush and close resources that were opened to write results. This method
+     * should be called after all CKClassResults have been calculated and printed.
+     * 
+     * @throws IOException If the resources cannot be closed
+     */
+    public void flushAndClose() throws IOException {
+        this.classPrinter.flush();
+        this.classPrinter.close();
+        this.methodPrinter.flush();
+        this.methodPrinter.close();
+        this.variablePrinter.flush();
+        this.variablePrinter.close();
+        this.fieldPrinter.flush();
+        this.fieldPrinter.close();
+    }
+}


### PR DESCRIPTION
Addresses #17 

The effect of this change is that the CSVs are always valid, using the standard CSV (RFC 4180) format. For example, the method identifier `getValue/3[int[],int[],String]` will now be quoted in the output file, i.e., `"getValue/3[int[],int[],String]"`, making the file readable by CSV parsers like pandas or R.

I haven't written a test for this, since I would be testing [apache/commons-csv](https://github.com/apache/commons-csv), which seems to have a pretty good test suite.

Also fixed an issue where `result.getMathOperationsQty()` was written twice per row in `class.csv`.