### PR TITLE
Fix the number of default fields count

### DIFF
--- a/fixtures/fields/Fields.java
+++ b/fixtures/fields/Fields.java
@@ -7,5 +7,9 @@ public class Fields {
 	public double c;
 	private static String d;
 	public static int e;
+
+	int f;
+
+	private synchronized int j;
 	
 }

--- a/fixtures/fields/Fields.java
+++ b/fixtures/fields/Fields.java
@@ -9,6 +9,7 @@ public class Fields {
 	public static int e;
 
 	int f;
+	static int k;
 
 	private synchronized int j;
 	

--- a/src/main/java/com/github/mauricioaniche/ck/metric/NumberOfFields.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/NumberOfFields.java
@@ -33,7 +33,7 @@ public class NumberOfFields extends ASTVisitor implements ClassLevelMetric {
 		if(Modifier.isProtected(node.getModifiers()))
 			protectedFields++;
 
-		if(Modifier.isDefault(node.getModifiers()))
+		if(node.getModifiers() == 0)
 			defaultFields++;
 
 		if(Modifier.isFinal(node.getModifiers()))

--- a/src/main/java/com/github/mauricioaniche/ck/metric/NumberOfFields.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/NumberOfFields.java
@@ -21,25 +21,32 @@ public class NumberOfFields extends ASTVisitor implements ClassLevelMetric {
 	public boolean visit(FieldDeclaration node) {
 		fields++;
 
-		if(Modifier.isStatic(node.getModifiers()))
-			staticFields++;
 
-		if(Modifier.isPublic(node.getModifiers()))
+		boolean isPublic = Modifier.isPublic(node.getModifiers());
+		boolean isPrivate = Modifier.isPrivate(node.getModifiers());
+		boolean isProtected = Modifier.isProtected(node.getModifiers());
+
+		if(isPublic)
 			publicFields++;
-
-		if(Modifier.isPrivate(node.getModifiers()))
+		else if(isPrivate)
 			privateFields++;
-
-		if(Modifier.isProtected(node.getModifiers()))
+		else if(isProtected)
 			protectedFields++;
-
-		if(node.getModifiers() == 0)
+		else
 			defaultFields++;
 
-		if(Modifier.isFinal(node.getModifiers()))
+		// other characteristics rather than visibility
+		boolean isStatic = Modifier.isStatic(node.getModifiers());
+		boolean isFinal = Modifier.isFinal(node.getModifiers());
+		boolean isSynchronized = Modifier.isSynchronized(node.getModifiers());
+		
+		if(isStatic)
+			staticFields++;
+
+		if(isFinal)
 			finalFields++;
 
-		if(Modifier.isSynchronized(node.getModifiers()))
+		if(isSynchronized)
 			synchronizedFields++;
 
 		return false;

--- a/src/test/java/com/github/mauricioaniche/ck/metric/FieldsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/metric/FieldsTest.java
@@ -21,7 +21,7 @@ public class FieldsTest extends BaseTest {
 	@Test
 	public void all() {
 		CKClassResult a = report.get("fields.Fields");
-		Assert.assertEquals(5, a.getNumberOfFields());
+		Assert.assertEquals(7, a.getNumberOfFields());
 	}
 
 	@Test
@@ -34,5 +34,25 @@ public class FieldsTest extends BaseTest {
 	public void allStatic() {
 		CKClassResult a = report.get("fields.Fields");
 		Assert.assertEquals(2, a.getNumberOfStaticFields());
+	}
+
+
+	@Test
+	public void allPrivate() {
+		CKClassResult a = report.get("fields.Fields");
+		Assert.assertEquals(4, a.getNumberOfPrivateFields());
+	}
+
+
+	@Test
+	public void allDefault() {
+		CKClassResult a = report.get("fields.Fields");
+		Assert.assertEquals(1, a.getNumberOfDefaultFields());
+	}
+
+	@Test
+	public void allSynchronized() {
+		CKClassResult a = report.get("fields.Fields");
+		Assert.assertEquals(1, a.getNumberOfSynchronizedFields());
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/metric/FieldsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/metric/FieldsTest.java
@@ -21,7 +21,7 @@ public class FieldsTest extends BaseTest {
 	@Test
 	public void all() {
 		CKClassResult a = report.get("fields.Fields");
-		Assert.assertEquals(7, a.getNumberOfFields());
+		Assert.assertEquals(8, a.getNumberOfFields());
 	}
 
 	@Test
@@ -33,7 +33,7 @@ public class FieldsTest extends BaseTest {
 	@Test
 	public void allStatic() {
 		CKClassResult a = report.get("fields.Fields");
-		Assert.assertEquals(2, a.getNumberOfStaticFields());
+		Assert.assertEquals(3, a.getNumberOfStaticFields());
 	}
 
 
@@ -47,7 +47,7 @@ public class FieldsTest extends BaseTest {
 	@Test
 	public void allDefault() {
 		CKClassResult a = report.get("fields.Fields");
-		Assert.assertEquals(1, a.getNumberOfDefaultFields());
+		Assert.assertEquals(2, a.getNumberOfDefaultFields());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #24 

The `isDefault()` method used to count the number of default fields actually only work on methods... See documentation.

The implementation is now a bit smarter. First, it compares among all the possible visibility modifiers (public, private, default, protected). Then, later, compares the other stuff (final, synchronised, static).