### PR TITLE
New feature to include method reference in RFC metric

### DIFF
--- a/fixtures/rfc/RFC6.java
+++ b/fixtures/rfc/RFC6.java
@@ -1,0 +1,9 @@
+package rfc;
+
+class RFC6 {
+  private ComplexClassBuilder ccb = new ComplexClassBuilder();
+
+  public void x() {
+    ccb.builder().wings(3).hasHorn().legs(4);
+  }
+}

--- a/fixtures/rfc/RFC7.java
+++ b/fixtures/rfc/RFC7.java
@@ -1,0 +1,18 @@
+package rfc;
+
+class RFC7 {
+  public void m1() {
+    Integer[] someNumbers = {1, 2, null, 4};
+
+    Stream.of(someNumbers).map(n -> n * 2).filter(n -> n != null).findFirst().orElse(null);
+  }
+
+  public void m2() {
+    Map<Character, List<Integer>> byAlphabet =
+        aList.stream()
+            .collect(
+                Collectors.groupingBy(
+                    e -> new Character(e.getName().charAt(0)),
+                    Collectors.mapping(Avatar::getId, Collectors.toList())));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,255 +1,255 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.github.mauricioaniche</groupId>
-	<artifactId>ck</artifactId>
-	<packaging>jar</packaging>
-	<version>0.5.3-SNAPSHOT</version>
-	<name>CK calculator</name>
-	<url>http://www.mauricioaniche.com</url>
-	<description>Java code metrics calculator</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.github.mauricioaniche</groupId>
+    <artifactId>ck</artifactId>
+    <packaging>jar</packaging>
+    <version>0.5.3-SNAPSHOT</version>
+    <name>CK calculator</name>
+    <url>http://www.mauricioaniche.com</url>
+    <description>Java code metrics calculator</description>
 
-	<licenses>
-		<license>
-			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-	<developers>
-		<developer>
-			<id>mauricioaniche</id>
-			<name>Mauricio Aniche</name>
-			<email>mauricioaniche@gmail.com</email>
-			<organization>Delft University of Technology</organization>
-			<roles>
-				<role>developer</role>
-			</roles>
-			<timezone>-3</timezone>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <id>mauricioaniche</id>
+            <name>Mauricio Aniche</name>
+            <email>mauricioaniche@gmail.com</email>
+            <organization>Delft University of Technology</organization>
+            <roles>
+                <role>developer</role>
+            </roles>
+            <timezone>-3</timezone>
+        </developer>
+    </developers>
 
-	<scm>
-		<url>http://github.com/mauricioaniche/ck</url>
-		<connection>scm:git:git://github.com/mauricioaniche/ck</connection>
-		<developerConnection>scm:git:git@github.com:mauricioaniche/ck.git</developerConnection>
-		<tag>HEAD</tag>
-	</scm>
+    <scm>
+        <url>http://github.com/mauricioaniche/ck</url>
+        <connection>scm:git:git://github.com/mauricioaniche/ck</connection>
+        <developerConnection>scm:git:git@github.com:mauricioaniche/ck.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
 
-	<dependencies>
+    <dependencies>
 
-		<dependency>
-			<groupId>org.reflections</groupId>
-			<artifactId>reflections</artifactId>
-			<version>0.9.11</version>
-		</dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.11</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.eclipse.jdt</groupId>
-			<artifactId>org.eclipse.jdt.core</artifactId>
-			<version>3.17.0</version>
-		</dependency>
+        <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.core</artifactId>
+            <version>3.17.0</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.10.8</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.8</version>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>20.0</version>
-		</dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.0</version>
-		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.6.0</version>
+        </dependency>
 
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
-		</dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+        </dependency>
 
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12-beta-3</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.4</version>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.7</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-csv</artifactId>
-			<version>1.7</version>
-		</dependency>
+        <!-- https://mvnrepository.com/artifact/org.pitest/pitest-maven -->
+        <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <version>1.4.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.5.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-		<!-- https://mvnrepository.com/artifact/org.pitest/pitest-maven -->
-		<dependency>
-			<groupId>org.pitest</groupId>
-			<artifactId>pitest-maven</artifactId>
-			<version>1.4.11</version>
-		</dependency>
-	</dependencies>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
-	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
+    <build>
+        <plugins>
 
-	<build>
-		<plugins>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>1.4.11</version>
+                <configuration>
+                    <targetClasses>
+                        <param>com.github.mauricioaniche.ck.*</param>
+                    </targetClasses>
+                    <targetTests>
+                        <param>com.github.mauricioaniche.ck.*</param>
+                    </targetTests>
+                </configuration>
+            </plugin>
 
-			<plugin>
-				<groupId>org.pitest</groupId>
-				<artifactId>pitest-maven</artifactId>
-				<version>1.4.11</version>
-				<configuration>
-					<targetClasses>
-						<param>com.github.mauricioaniche.ck.*</param>
-					</targetClasses>
-					<targetTests>
-						<param>com.github.mauricioaniche.ck.*</param>
-					</targetTests>
-				</configuration>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifest>
-							<mainClass>com.github.mauricioaniche.ck.Runner</mainClass>
-						</manifest>
-					</archive>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-				</configuration>
-			</plugin>
-
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.1</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.scm</groupId>
-						<artifactId>maven-scm-provider-gitexe</artifactId>
-						<version>1.9.2</version>
-					</dependency>
-				</dependencies>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>3.1.0</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-						<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.1</version>
-				<configuration>
-					<doclint>none</doclint>
-					<source>8</source>
-				</configuration>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-						<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.5</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>report</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.github.mauricioaniche.ck.Runner</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
 
 
-		</plugins>
-	</build>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-provider-gitexe</artifactId>
+                        <version>1.9.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
 
-	<profiles>
-		<profile>
-			<id>release-sign-artifacts</id>
-			<activation>
-				<property>
-					<name>performRelease</name>
-					<value>true</value>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <doclint>none</doclint>
+                    <source>8</source>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/com/github/mauricioaniche/ck/metric/RFC.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/RFC.java
@@ -6,53 +6,63 @@ import org.eclipse.jdt.core.dom.*;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class RFC implements CKASTVisitor, ClassLevelMetric, MethodLevelMetric {
 
-	private HashSet<String> methodInvocations = new HashSet<String>();
+  private final HashSet<String> methodInvocations = new HashSet<>();
 
-	public void visit(MethodInvocation node) {
-		IMethodBinding binding = node.resolveMethodBinding();
-		count(node.getName()  + "/" + arguments(node.arguments()), binding);
-	}
+  public void visit(MethodInvocation node) {
+    IMethodBinding binding = node.resolveMethodBinding();
+    count(node.getName() + "/" + arguments(node.arguments()), binding);
+  }
 
-	private String arguments(List<?> arguments) {
-		if(arguments==null || arguments.isEmpty()) return "0";
-		return "" + arguments.size();
-	}
+  private void count(String methodName, IMethodBinding binding) {
+    if (binding != null) {
+      String method = getMethodName(binding);
+      methodInvocations.add(method);
+    } else {
+      methodInvocations.add(methodName);
+    }
+  }
 
-	private void count(String methodName, IMethodBinding binding) {
-		if(binding!=null) {
-			String method = getMethodName(binding);
-			methodInvocations.add(method);
-		} else {
-			methodInvocations.add(methodName);
-		}
-	}
-	
-	public void visit(SuperMethodInvocation node) {
-		IMethodBinding binding = node.resolveMethodBinding();
-		count(node.getName()  + "/" + arguments(node.arguments()), binding);
-	}
+  private String arguments(List<?> arguments) {
+    if (arguments == null || arguments.isEmpty()) return "0";
+    return "" + arguments.size();
+  }
 
-	private String getMethodName(IMethodBinding binding) {
-		
-		String argumentList = "";
-		ITypeBinding[] args = binding.getParameterTypes();
-		for(ITypeBinding arg : args) {
-			argumentList += arg.getName();
-		}
-		String method = binding.getDeclaringClass().getQualifiedName() + "." + binding.getName() + "/" + binding.getTypeArguments().length + "[" + argumentList + "]";
-		return method;
-	}
-	
-	@Override
-	public void setResult(CKClassResult result) {
-		result.setRfc(methodInvocations.size());
-	}
+  private String getMethodName(IMethodBinding binding) {
+    ITypeBinding[] args = binding.getParameterTypes();
+    String argumentList = Stream.of(args).map(ITypeBinding::getName).reduce("", (s, s2) -> s + s2);
+    String method =
+        binding.getDeclaringClass().getQualifiedName()
+            + "."
+            + binding.getName()
+            + "/"
+            + binding.getTypeArguments().length
+            + "["
+            + argumentList
+            + "]";
+    return method;
+  }
 
-	@Override
-	public void setResult(CKMethodResult result) {
-		result.setRfc(methodInvocations.size());
-	}
+  public void visit(SuperMethodInvocation node) {
+    IMethodBinding binding = node.resolveMethodBinding();
+    count(node.getName() + "/" + arguments(node.arguments()), binding);
+  }
+
+  public void visit(ExpressionMethodReference node) {
+    IMethodBinding binding = node.resolveMethodBinding();
+    count(node.getName().toString(), binding);
+  }
+
+  @Override
+  public void setResult(CKClassResult result) {
+    result.setRfc(methodInvocations.size());
+  }
+
+  @Override
+  public void setResult(CKMethodResult result) {
+    result.setRfc(methodInvocations.size());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/ASTDebugger.java
+++ b/src/test/java/com/github/mauricioaniche/ck/ASTDebugger.java
@@ -6,375 +6,461 @@ import org.eclipse.jdt.core.dom.*;
 
 public class ASTDebugger implements CKASTVisitor, ClassLevelMetric {
 
-
-	public void visit(AnnotationTypeDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(AnnotationTypeMemberDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(AnonymousClassDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ArrayAccess node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ArrayCreation node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ArrayInitializer node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ArrayType node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(AssertStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(Assignment node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(Block node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(BlockComment node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(BooleanLiteral node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(BreakStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(CastExpression node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(CatchClause node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(CharacterLiteral node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ClassInstanceCreation node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(CompilationUnit node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ConditionalExpression node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ConstructorInvocation node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ContinueStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(CreationReference node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(Dimension node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(DoStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(EmptyStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(EnhancedForStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(EnumConstantDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(EnumDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ExpressionMethodReference node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ExpressionStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(FieldAccess node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(FieldDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ForStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(IfStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ImportDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(InfixExpression node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(Initializer node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(InstanceofExpression node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(IntersectionType node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(LabeledStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(LambdaExpression node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(LineComment node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(MarkerAnnotation node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(MemberRef node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(MemberValuePair node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(MethodRef node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(MethodRefParameter node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(MethodDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(MethodInvocation node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(Modifier node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(NameQualifiedType node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(NormalAnnotation node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(NullLiteral node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(NumberLiteral node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(PackageDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ParameterizedType node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ParenthesizedExpression node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(PostfixExpression node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(PrefixExpression node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(PrimitiveType node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(QualifiedName node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(QualifiedType node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ReturnStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SimpleName node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SimpleType node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SingleMemberAnnotation node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SingleVariableDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(StringLiteral node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SuperConstructorInvocation node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SuperFieldAccess node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SuperMethodInvocation node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SuperMethodReference node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SwitchCase node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SwitchStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(SynchronizedStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(TagElement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(TextElement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ThisExpression node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(ThrowStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(TryStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(TypeDeclaration node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(TypeDeclarationStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(TypeLiteral node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(TypeMethodReference node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(TypeParameter node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(UnionType node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(VariableDeclarationExpression node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(VariableDeclarationStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(VariableDeclarationFragment node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(WhileStatement node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-	public void visit(WildcardType node) {
-		System.out.println("-- " + node.getClass().getSimpleName()); System.out.println(node.toString());
-	}
-
-
-
-	@Override
-	public void setResult(CKClassResult result) {
-
-	}
+  public void visit(AnnotationTypeDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(AnnotationTypeMemberDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(AnonymousClassDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ArrayAccess node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ArrayCreation node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ArrayInitializer node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ArrayType node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(AssertStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(Assignment node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(Block node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(BlockComment node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(BooleanLiteral node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(BreakStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(CastExpression node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(CatchClause node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(CharacterLiteral node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ClassInstanceCreation node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(CompilationUnit node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ConditionalExpression node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ConstructorInvocation node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ContinueStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(CreationReference node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(Dimension node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(DoStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(EmptyStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(EnhancedForStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(EnumConstantDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(EnumDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ExpressionMethodReference node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ExpressionStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(FieldAccess node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(FieldDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ForStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(IfStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ImportDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(InfixExpression node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(Initializer node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(InstanceofExpression node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(IntersectionType node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(LabeledStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(LambdaExpression node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(LineComment node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(MarkerAnnotation node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(MemberRef node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(MemberValuePair node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(MethodRef node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(MethodRefParameter node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(MethodDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(MethodInvocation node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(Modifier node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(NameQualifiedType node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(NormalAnnotation node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(NullLiteral node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(NumberLiteral node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(PackageDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ParameterizedType node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ParenthesizedExpression node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(PostfixExpression node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(PrefixExpression node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(PrimitiveType node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(QualifiedName node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(QualifiedType node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ReturnStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SimpleName node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SimpleType node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SingleMemberAnnotation node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SingleVariableDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(StringLiteral node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SuperConstructorInvocation node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SuperFieldAccess node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SuperMethodInvocation node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SuperMethodReference node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SwitchCase node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SwitchStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(SynchronizedStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(TagElement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(TextElement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ThisExpression node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(ThrowStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(TryStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(TypeDeclaration node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(TypeDeclarationStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(TypeLiteral node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(TypeMethodReference node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(TypeParameter node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(UnionType node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(VariableDeclarationExpression node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(VariableDeclarationStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(VariableDeclarationFragment node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(WhileStatement node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  public void visit(WildcardType node) {
+    System.out.println("-- " + node.getClass().getSimpleName());
+    System.out.println(node.toString());
+  }
+
+  @Override
+  public void setResult(CKClassResult result) {}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/BaseTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/BaseTest.java
@@ -5,7 +5,10 @@ import com.github.mauricioaniche.ck.metric.MethodLevelMetric;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 public abstract class BaseTest {
@@ -22,7 +25,7 @@ public abstract class BaseTest {
   }
 
   protected static Map<String, CKClassResult> runDebug(String dir) {
-    return run(dir, () -> Arrays.asList(new ASTDebugger()), () -> Collections.emptyList());
+    return run(dir, () -> Collections.singletonList(new ASTDebugger()), Collections::emptyList);
   }
 
   protected static Map<String, CKClassResult> run(String dir) {

--- a/src/test/java/com/github/mauricioaniche/ck/BaseTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/BaseTest.java
@@ -10,28 +10,34 @@ import java.util.concurrent.Callable;
 
 public abstract class BaseTest {
 
-	protected static String fixturesDir() {
-		try {
-			String cfgFile = new File(BaseTest.class.getResource("/").getPath() + "../../fixtures/").getCanonicalPath();
-			return cfgFile;
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+  protected static String fixturesDir() {
+    try {
+      String cfgFile =
+          new File(BaseTest.class.getResource("/").getPath() + "../../fixtures/")
+              .getCanonicalPath();
+      return cfgFile;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-	protected static Map<String, CKClassResult> runDebug(String dir) {
-		return run(dir, () -> Arrays.asList(new ASTDebugger()), () -> Collections.emptyList());
-	}
+  protected static Map<String, CKClassResult> runDebug(String dir) {
+    return run(dir, () -> Arrays.asList(new ASTDebugger()), () -> Collections.emptyList());
+  }
 
-	protected static Map<String, CKClassResult> run(String dir) {
-		Map<String, CKClassResult> map = new HashMap<>();
-		new CK().calculate(dir, result -> map.put(result.getClassName(), result));
-		return map;
-	}
+  protected static Map<String, CKClassResult> run(String dir) {
+    Map<String, CKClassResult> map = new HashMap<>();
+    new CK().calculate(dir, result -> map.put(result.getClassName(), result));
+    return map;
+  }
 
-	protected static Map<String, CKClassResult> run(String dir, Callable<List<ClassLevelMetric>> classLevelMetrics, Callable<List<MethodLevelMetric>> methodLevelMetrics) {
-		Map<String, CKClassResult> map = new HashMap<>();
-		new CK(classLevelMetrics, methodLevelMetrics).calculate(dir, result -> map.put(result.getClassName(), result));
-		return map;
-	}
+  protected static Map<String, CKClassResult> run(
+      String dir,
+      Callable<List<ClassLevelMetric>> classLevelMetrics,
+      Callable<List<MethodLevelMetric>> methodLevelMetrics) {
+    Map<String, CKClassResult> map = new HashMap<>();
+    new CK(classLevelMetrics, methodLevelMetrics)
+        .calculate(dir, result -> map.put(result.getClassName(), result));
+    return map;
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/BindingsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/BindingsTest.java
@@ -1,31 +1,29 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class BindingsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/bindings");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/bindings");
+  }
 
+  @Test
+  public void fullNameEvenWhenTypesAreNotAvailable() {
+    CKClassResult a = report.get("bind.BindingFail1");
+    Assertions.assertNotNull(a);
+  }
 
-	@Test
-	public void fullNameEvenWhenTypesAreNotAvailable() {
-		CKClassResult a = report.get("bind.BindingFail1");
-		Assert.assertNotNull(a);
-	}
-
-	@Test
-	public void fullNameEvenWhenTypesAreNotAvailableNotEvenInImports() {
-		CKClassResult a = report.get("bind.BindingFail2");
-		Assert.assertNotNull(a);
-	}
-
+  @Test
+  public void fullNameEvenWhenTypesAreNotAvailableNotEvenInImports() {
+    CKClassResult a = report.get("bind.BindingFail2");
+    Assertions.assertNotNull(a);
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/CBOTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/CBOTest.java
@@ -1,95 +1,94 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class CBOTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/cbo");
-	}
-	
-	@Test
-	public void ignoreJavaTypes() {
-		CKClassResult a = report.get("cbo.Coupling0");
-		Assert.assertEquals(0, a.getCbo());
-	}
-	
-	@Test
-	public void countDifferentPossibilitiesOfDependencies() {
-		
-		CKClassResult a = report.get("cbo.Coupling1");
-		Assert.assertEquals(6, a.getCbo());
-	}
-	
-	@Test
-	public void countEvenWhenNotResolved() {
-		
-		CKClassResult a = report.get("cbo.Coupling3");
-		Assert.assertEquals(1, a.getCbo());
-	}
-	
-	@Test
-	public void countInterfacesAndInheritances() {
-		
-		CKClassResult b = report.get("cbo.Coupling2");
-		Assert.assertEquals(5, b.getCbo());
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/cbo");
+  }
 
-	@Test
-	public void countClassCreations() {
-		CKClassResult b = report.get("cbo.Coupling4");
-		Assert.assertEquals(3, b.getCbo());
-	}
+  @Test
+  public void ignoreJavaTypes() {
+    CKClassResult a = report.get("cbo.Coupling0");
+    Assertions.assertEquals(0, a.getCbo());
+  }
 
-	@Test
-	public void countMethodParameters() {
-		
-		CKClassResult b = report.get("cbo.MethodParams");
-		Assert.assertEquals(2, b.getCbo());
-	}
+  @Test
+  public void countDifferentPossibilitiesOfDependencies() {
 
-	@Test
-	public void methodLevel() {
-		CKClassResult b = report.get("cbo.Coupling5");
-		Assert.assertEquals(0, b.getMethod("am1/0").get().getCbo());
-		Assert.assertEquals(1, b.getMethod("am2/0").get().getCbo());
-		Assert.assertEquals(1, b.getMethod("am3/0").get().getCbo());
-		Assert.assertEquals(2, b.getMethod("am4/0").get().getCbo());
-	}
+    CKClassResult a = report.get("cbo.Coupling1");
+    Assertions.assertEquals(6, a.getCbo());
+  }
 
-	@Test
-	public void fullOfNonResolvedTypes() {
-		CKClassResult b = report.get("cbo.NotResolved");
-		Assert.assertEquals(5, b.getCbo());
-	}
+  @Test
+  public void countEvenWhenNotResolved() {
 
-	// based on issue #43
-	@Test
-	public void couplingWithGenericsAndJavaType() {
-		CKClassResult b = report.get("cbo.Coupling6");
-		Assert.assertEquals(1, b.getCbo());
+    CKClassResult a = report.get("cbo.Coupling3");
+    Assertions.assertEquals(1, a.getCbo());
+  }
 
-		CKClassResult c = report.get("cbo.Coupling61");
-		Assert.assertEquals(1, c.getCbo());
+  @Test
+  public void countInterfacesAndInheritances() {
 
-		CKClassResult d = report.get("cbo.Coupling62");
-		Assert.assertEquals(2, d.getCbo());
+    CKClassResult b = report.get("cbo.Coupling2");
+    Assertions.assertEquals(5, b.getCbo());
+  }
 
-		CKClassResult e = report.get("cbo.Coupling63");
-		Assert.assertEquals(2, e.getCbo());
+  @Test
+  public void countClassCreations() {
+    CKClassResult b = report.get("cbo.Coupling4");
+    Assertions.assertEquals(3, b.getCbo());
+  }
 
-		CKClassResult f = report.get("cbo.Coupling64");
-		Assert.assertEquals(2, f.getCbo());
+  @Test
+  public void countMethodParameters() {
 
-		CKClassResult g = report.get("cbo.Coupling65");
-		Assert.assertEquals(2, g.getCbo());
+    CKClassResult b = report.get("cbo.MethodParams");
+    Assertions.assertEquals(2, b.getCbo());
+  }
 
-	}
+  @Test
+  public void methodLevel() {
+    CKClassResult b = report.get("cbo.Coupling5");
+    Assertions.assertEquals(0, b.getMethod("am1/0").get().getCbo());
+    Assertions.assertEquals(1, b.getMethod("am2/0").get().getCbo());
+    Assertions.assertEquals(1, b.getMethod("am3/0").get().getCbo());
+    Assertions.assertEquals(2, b.getMethod("am4/0").get().getCbo());
+  }
+
+  @Test
+  public void fullOfNonResolvedTypes() {
+    CKClassResult b = report.get("cbo.NotResolved");
+    Assertions.assertEquals(5, b.getCbo());
+  }
+
+  // based on issue #43
+  @Test
+  public void couplingWithGenericsAndJavaType() {
+    CKClassResult b = report.get("cbo.Coupling6");
+    Assertions.assertEquals(1, b.getCbo());
+
+    CKClassResult c = report.get("cbo.Coupling61");
+    Assertions.assertEquals(1, c.getCbo());
+
+    CKClassResult d = report.get("cbo.Coupling62");
+    Assertions.assertEquals(2, d.getCbo());
+
+    CKClassResult e = report.get("cbo.Coupling63");
+    Assertions.assertEquals(2, e.getCbo());
+
+    CKClassResult f = report.get("cbo.Coupling64");
+    Assertions.assertEquals(2, f.getCbo());
+
+    CKClassResult g = report.get("cbo.Coupling65");
+    Assertions.assertEquals(2, g.getCbo());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/ClassTypeTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/ClassTypeTest.java
@@ -1,45 +1,38 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 
 public class ClassTypeTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/class-types");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/class-types");
+  }
 
+  @Test
+  public void identifyTypesCorrectly() {
 
-	@Test
-	public void identifyTypesCorrectly() {
+    Assertions.assertEquals(5, report.size());
 
-		Assert.assertEquals(5, report.size());
+    CKClassResult a = report.get("classtypes.A");
+    Assertions.assertEquals("class", a.getType());
 
-		CKClassResult a = report.get("classtypes.A");
-		Assert.assertEquals("class", a.getType());
+    CKClassResult b = report.get("classtypes.A$B");
+    Assertions.assertEquals("innerclass", b.getType());
 
-		CKClassResult b = report.get("classtypes.A$B");
-		Assert.assertEquals("innerclass", b.getType());
+    CKClassResult mathOperation = report.get("classtypes.MathOperation");
+    Assertions.assertEquals("interface", mathOperation.getType());
 
-		CKClassResult mathOperation = report.get("classtypes.MathOperation");
-		Assert.assertEquals("interface", mathOperation.getType());
+    CKClassResult anon1 = report.get("classtypes.A$Anonymous1");
+    Assertions.assertEquals("anonymous", anon1.getType());
 
-		CKClassResult anon1 = report.get("classtypes.A$Anonymous1");
-		Assert.assertEquals("anonymous", anon1.getType());
-
-		CKClassResult anon2 = report.get("classtypes.A$Anonymous2");
-		Assert.assertEquals("anonymous", anon2.getType());
-
-
-	}
-
-
+    CKClassResult anon2 = report.get("classtypes.A$Anonymous2");
+    Assertions.assertEquals("anonymous", anon2.getType());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/DITTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/DITTest.java
@@ -1,52 +1,50 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class DITTest extends BaseTest {
 
+  private static Map<String, CKClassResult> report;
 
-	private static Map<String, CKClassResult> report;
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/dit");
+  }
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/dit");
-	}
-	
-	@Test
-	public void everyOneHasObjectAsFather() {
-		CKClassResult a = report.get("dit.A");
-		Assert.assertEquals(1, a.getDit());
-	}
+  @Test
+  public void everyOneHasObjectAsFather() {
+    CKClassResult a = report.get("dit.A");
+    Assertions.assertEquals(1, a.getDit());
+  }
 
-	@Test
-	public void firstLevelInheritance() {
-		CKClassResult b = report.get("dit.B");
-		Assert.assertEquals(2, b.getDit());
-	}
-	
-	@Test
-	public void twoLevelsInheritance() {
-		CKClassResult c = report.get("dit.C");
-		Assert.assertEquals(3, c.getDit());
+  @Test
+  public void firstLevelInheritance() {
+    CKClassResult b = report.get("dit.B");
+    Assertions.assertEquals(2, b.getDit());
+  }
 
-		CKClassResult c2 = report.get("dit.C2");
-		Assert.assertEquals(3, c2.getDit());
-	}
-	
-	@Test
-	public void threeLevelsInheritance() {
-		CKClassResult d = report.get("dit.D");
-		Assert.assertEquals(4, d.getDit());
-	}
-	
-	@Test
-	public void countEvenClassesNotResolved() {
-		CKClassResult a = report.get("dit.X");
-		Assert.assertEquals(2, a.getDit());
-	}
+  @Test
+  public void twoLevelsInheritance() {
+    CKClassResult c = report.get("dit.C");
+    Assertions.assertEquals(3, c.getDit());
 
+    CKClassResult c2 = report.get("dit.C2");
+    Assertions.assertEquals(3, c2.getDit());
+  }
+
+  @Test
+  public void threeLevelsInheritance() {
+    CKClassResult d = report.get("dit.D");
+    Assertions.assertEquals(4, d.getDit());
+  }
+
+  @Test
+  public void countEvenClassesNotResolved() {
+    CKClassResult a = report.get("dit.X");
+    Assertions.assertEquals(2, a.getDit());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/EnumTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/EnumTest.java
@@ -1,54 +1,50 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class EnumTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/enumdecl");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/enumdecl");
+  }
 
-	@Test
-	public void testEnum() {
-		CKClassResult a = report.get("enumd.EnumDecl");
+  @Test
+  public void testEnum() {
+    CKClassResult a = report.get("enumd.EnumDecl");
 
-		Assert.assertEquals(2, a.getMethods().size());
+    Assertions.assertEquals(2, a.getMethods().size());
 
-		CKMethodResult m1 = a.getMethods().stream().filter(x -> x.getMethodName().contains("getX")).findFirst().get();
-		Assert.assertEquals("getX/0", m1.getMethodName());
-		Assert.assertEquals(1, m1.getReturnQty());
-		Assert.assertEquals(1, m1.getLoopQty());
+    CKMethodResult m1 =
+        a.getMethods().stream().filter(x -> x.getMethodName().contains("getX")).findFirst().get();
+    Assertions.assertEquals("getX/0", m1.getMethodName());
+    Assertions.assertEquals(1, m1.getReturnQty());
+    Assertions.assertEquals(1, m1.getLoopQty());
+  }
 
-	}
+  @Test
+  public void maxNestedDepth() {
+    CKClassResult b = report.get("enumd.EnumDecl2");
+    Assertions.assertEquals(1, b.getMethod("url/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(4, b.getMethod("m2/0").get().getMaxNestedBlocks());
+  }
 
-	@Test
-	public void maxNestedDepth() {
-		CKClassResult b = report.get("enumd.EnumDecl2");
-		Assert.assertEquals(1, b.getMethod("url/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(4, b.getMethod("m2/0").get().getMaxNestedBlocks());
-	}
+  @Test
+  public void subclasses() {
+    CKClassResult b = report.get("enumd.EnumDecl3");
 
-	@Test
-	public void subclasses() {
-		CKClassResult b = report.get("enumd.EnumDecl3");
+    Assertions.assertEquals(1, b.getMethod("getX/0").get().getInnerClassesQty());
+    Assertions.assertEquals(2, b.getInnerClassesQty());
 
-		Assert.assertEquals(1, b.getMethod("getX/0").get().getInnerClassesQty());
-		Assert.assertEquals(2, b.getInnerClassesQty());
-
-		CKClassResult sc = report.get("enumd.EnumDecl3$1Other");
-		Assert.assertEquals(4, sc.getNumberOfMethods());
-		Assert.assertEquals(3, sc.getMethod("x1/0").get().getWmc());
-		Assert.assertEquals(2, sc.getMethod("x1/0").get().getVariablesQty());
-
-	}
-
-
-
+    CKClassResult sc = report.get("enumd.EnumDecl3$1Other");
+    Assertions.assertEquals(4, sc.getNumberOfMethods());
+    Assertions.assertEquals(3, sc.getMethod("x1/0").get().getWmc());
+    Assertions.assertEquals(2, sc.getMethod("x1/0").get().getVariablesQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/FieldUsageTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/FieldUsageTest.java
@@ -1,44 +1,44 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class FieldUsageTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/fieldusage");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/fieldusage");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("fieldusage.FieldUsage");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("fieldusage.FieldUsage");
 
-		CKMethodResult m1 = a.getMethod("m1/0").get();
-		Map<String, Integer> m1Fields = m1.getFieldUsage();
-		Assert.assertEquals(2, m1Fields.get("a").intValue());
-		Assert.assertEquals(1, m1Fields.get("b").intValue());
+    CKMethodResult m1 = a.getMethod("m1/0").get();
+    Map<String, Integer> m1Fields = m1.getFieldUsage();
+    Assertions.assertEquals(2, m1Fields.get("a").intValue());
+    Assertions.assertEquals(1, m1Fields.get("b").intValue());
 
-		CKMethodResult m3 = a.getMethod("m3/0").get();
-		Map<String, Integer> m3Fields = m3.getFieldUsage();
-		Assert.assertEquals(2, m3Fields.get("a").intValue());
+    CKMethodResult m3 = a.getMethod("m3/0").get();
+    Map<String, Integer> m3Fields = m3.getFieldUsage();
+    Assertions.assertEquals(2, m3Fields.get("a").intValue());
 
-		CKMethodResult m2 = a.getMethod("m2/0").get();
-		Map<String, Integer> m2Fields = m2.getFieldUsage();
-		Assert.assertEquals(1, m2Fields.get("a").intValue());
-	}
+    CKMethodResult m2 = a.getMethod("m2/0").get();
+    Map<String, Integer> m2Fields = m2.getFieldUsage();
+    Assertions.assertEquals(1, m2Fields.get("a").intValue());
+  }
 
-	@Test
-	public void fieldsThatAreDeclaredAfter() {
-		CKClassResult a = report.get("fieldusage.FieldUsage");
+  @Test
+  public void fieldsThatAreDeclaredAfter() {
+    CKClassResult a = report.get("fieldusage.FieldUsage");
 
-		CKMethodResult m4 = a.getMethod("m4/0").get();
-		Map<String, Integer> m2Fields = m4.getFieldUsage();
-		Assert.assertEquals(2, m2Fields.get("xx").intValue());
-	}
+    CKMethodResult m4 = a.getMethod("m4/0").get();
+    Map<String, Integer> m2Fields = m4.getFieldUsage();
+    Assertions.assertEquals(2, m2Fields.get("xx").intValue());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/FieldsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/FieldsTest.java
@@ -1,69 +1,65 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class FieldsTest extends BaseTest {
 
+  private static Map<String, CKClassResult> report;
 
-    private static Map<String, CKClassResult> report;
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/fields");
+  }
 
-    @BeforeClass
-    public static void setUp() {
-        report = run(fixturesDir() + "/fields");
-    }
+  @Test
+  public void all() {
+    CKClassResult a = report.get("fields.Fields");
+    Assertions.assertEquals(10, a.getNumberOfFields());
+  }
 
-    @Test
-    public void all() {
-        CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(10, a.getNumberOfFields());
-    }
+  @Test
+  public void allPublic() {
+    CKClassResult a = report.get("fields.Fields");
+    Assertions.assertEquals(3, a.getNumberOfPublicFields());
+  }
 
-    @Test
-    public void allPublic() {
-        CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(3, a.getNumberOfPublicFields());
-    }
+  @Test
+  public void allStatic() {
+    CKClassResult a = report.get("fields.Fields");
+    Assertions.assertEquals(3, a.getNumberOfStaticFields());
+  }
 
-    @Test
-    public void allStatic() {
-        CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(3, a.getNumberOfStaticFields());
-    }
+  @Test
+  public void allPrivate() {
+    CKClassResult a = report.get("fields.Fields");
+    Assertions.assertEquals(4, a.getNumberOfPrivateFields());
+  }
 
+  @Test
+  public void allDefault() {
+    CKClassResult a = report.get("fields.Fields");
+    Assertions.assertEquals(2, a.getNumberOfDefaultFields());
+  }
 
-    @Test
-    public void allPrivate() {
-        CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(4, a.getNumberOfPrivateFields());
-    }
+  @Test
+  public void allSynchronized() {
+    CKClassResult a = report.get("fields.Fields");
+    Assertions.assertEquals(1, a.getNumberOfSynchronizedFields());
+  }
 
+  @Test
+  public void allProtected() {
+    CKClassResult a = report.get(("fields.Fields"));
+    Assertions.assertEquals(1, a.getNumberOfProtectedFields());
+  }
 
-    @Test
-    public void allDefault() {
-        CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(2, a.getNumberOfDefaultFields());
-    }
-
-    @Test
-    public void allSynchronized() {
-        CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(1, a.getNumberOfSynchronizedFields());
-    }
-
-    @Test
-    public void allProtected() {
-        CKClassResult a = report.get(("fields.Fields"));
-        Assert.assertEquals(1, a.getNumberOfProtectedFields());
-    }
-
-    @Test
-    public void AllFinal() {
-        CKClassResult a = report.get(("fields.Fields"));
-        Assert.assertEquals(1, a.getNumberOfFinalFields());
-
-    }
+  @Test
+  public void AllFinal() {
+    CKClassResult a = report.get(("fields.Fields"));
+    Assertions.assertEquals(1, a.getNumberOfFinalFields());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/GenericsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/GenericsTest.java
@@ -1,39 +1,49 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class GenericsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/generics");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/generics");
+  }
 
-	@Test
-	public void genericMethods() {
-		CKClassResult r = report.get("bg.Generics");
-		Assert.assertEquals(2, r.getMethods().size());
+  @Test
+  public void genericMethods() {
+    CKClassResult r = report.get("bg.Generics");
+    Assertions.assertEquals(2, r.getMethods().size());
 
-		// method names are the same, but starting line is different
-		Assert.assertEquals(1, r.getMethods().stream()
-				.filter(x -> x.getMethodName().equals("notEmpty/3[T,java.lang.String,java.lang.Object[]]") && x.getStartLine() == 9).count());
+    // method names are the same, but starting line is different
+    Assertions.assertEquals(
+        1,
+        r.getMethods().stream()
+            .filter(
+                x ->
+                    x.getMethodName().equals("notEmpty/3[T,java.lang.String,java.lang.Object[]]")
+                        && x.getStartLine() == 9)
+            .count());
 
-		Assert.assertEquals(1, r.getMethods().stream()
-				.filter(x -> x.getMethodName().equals("notEmpty/3[T,java.lang.String,java.lang.Object[]]") && x.getStartLine() == 13).count());
+    Assertions.assertEquals(
+        1,
+        r.getMethods().stream()
+            .filter(
+                x ->
+                    x.getMethodName().equals("notEmpty/3[T,java.lang.String,java.lang.Object[]]")
+                        && x.getStartLine() == 13)
+            .count());
+  }
 
-	}
+  @Test
+  public void noGenericsInClassName() {
+    CKClassResult r = report.get("bg.Generics2");
 
-	@Test
-	public void noGenericsInClassName() {
-		CKClassResult r = report.get("bg.Generics2");
-
-		Assert.assertNotNull(r);
-
-	}
+    Assertions.assertNotNull(r);
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/JDTUtilsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/JDTUtilsTest.java
@@ -1,27 +1,27 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class JDTUtilsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/jdt");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/jdt");
+  }
 
-	@Test
-	public void methodNames() {
-		CKClassResult a = report.get("jdt.Jdt1");
+  @Test
+  public void methodNames() {
+    CKClassResult a = report.get("jdt.Jdt1");
 
-		Assert.assertTrue(a.getMethod("m1/0").isPresent());
-		Assert.assertTrue(a.getMethod("m2/2[int,double]").isPresent());
-		Assert.assertTrue(a.getMethod("m3/3[int,jdt.A,double]").isPresent());
-		Assert.assertTrue(a.getMethod("m4/4[int,int[],java.lang.String[],jdt.A[]]").isPresent());
-	}
+    Assertions.assertTrue(a.getMethod("m1/0").isPresent());
+    Assertions.assertTrue(a.getMethod("m2/2[int,double]").isPresent());
+    Assertions.assertTrue(a.getMethod("m3/3[int,jdt.A,double]").isPresent());
+    Assertions.assertTrue(a.getMethod("m4/4[int,int[],java.lang.String[],jdt.A[]]").isPresent());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/Java11SupportTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/Java11SupportTest.java
@@ -1,31 +1,28 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 public class Java11SupportTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/java11");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/java11");
+  }
 
-	@Test
-	public void supportsJava11() {
-		assertTrue(this.report.containsKey("java11.Java11"));
-		CKClassResult clazz = this.report.get("java11.Java11");
-		Optional<CKMethodResult> maybeMethod = clazz.getMethod("m1/0");
-		assertTrue(maybeMethod.isPresent());
-		CKMethodResult method = maybeMethod.get();
-		assertEquals(1, method.getLambdasQty());
-	}
-
+  @Test
+  public void supportsJava11() {
+    Assertions.assertTrue(report.containsKey("java11.Java11"));
+    CKClassResult clazz = report.get("java11.Java11");
+    Optional<CKMethodResult> maybeMethod = clazz.getMethod("m1/0");
+    Assertions.assertTrue(maybeMethod.isPresent());
+    CKMethodResult method = maybeMethod.get();
+    Assertions.assertEquals(1, method.getLambdasQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/LCOMTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/LCOMTest.java
@@ -1,35 +1,33 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class LCOMTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/lcom");
-	}
-	
-	@Test
-	public void should_count_lcom() {
-		
-		CKClassResult a = report.get("lcom.TripStatusBean");
-		Assert.assertEquals(1415, a.getLcom());
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/lcom");
+  }
 
-		CKClassResult b = report.get("lcom.SimpleGetterAndSetter");
-		Assert.assertEquals(0, b.getLcom());
+  @Test
+  public void should_count_lcom() {
 
-		CKClassResult c = report.get("lcom.SimpleGetterAndSetter2");
-		Assert.assertEquals(2, c.getLcom());
+    CKClassResult a = report.get("lcom.TripStatusBean");
+    Assertions.assertEquals(1415, a.getLcom());
 
-		CKClassResult d = report.get("lcom.TermsOfServiceController");
-		Assert.assertEquals(0, d.getLcom());
+    CKClassResult b = report.get("lcom.SimpleGetterAndSetter");
+    Assertions.assertEquals(0, b.getLcom());
 
-	}
-	
+    CKClassResult c = report.get("lcom.SimpleGetterAndSetter2");
+    Assertions.assertEquals(2, c.getLcom());
+
+    CKClassResult d = report.get("lcom.TermsOfServiceController");
+    Assertions.assertEquals(0, d.getLcom());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/LOCTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/LOCTest.java
@@ -1,37 +1,36 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class LOCTest extends BaseTest {
 
-	@Test
-	public void countLinesIgnoringEmptyLines() {
-		Map<String, CKClassResult> report = run(fixturesDir() + "/cbo");
+  @Test
+  public void countLinesIgnoringEmptyLines() {
+    Map<String, CKClassResult> report = run(fixturesDir() + "/cbo");
 
-		CKClassResult a = report.get("cbo.Coupling1");
+    CKClassResult a = report.get("cbo.Coupling1");
 
-		// note that the package line should not count here
-		Assert.assertEquals(10, a.getLoc());
-	}
+    // note that the package line should not count here
+    Assertions.assertEquals(10, a.getLoc());
+  }
 
-	@Test
-	public void countLinesForInnerClasses() {
-		Map<String, CKClassResult> report = run(fixturesDir() + "/innerclasses");
+  @Test
+  public void countLinesForInnerClasses() {
+    Map<String, CKClassResult> report = run(fixturesDir() + "/innerclasses");
 
-		CKClassResult a = report.get("innerclasses.MessyClass");
-		Assert.assertEquals(65, a.getLoc());
+    CKClassResult a = report.get("innerclasses.MessyClass");
+    Assertions.assertEquals(65, a.getLoc());
 
-		CKClassResult sc1 = report.get("innerclasses.MessyClass$InnerClass1");
-		Assert.assertEquals(14, sc1.getLoc());
+    CKClassResult sc1 = report.get("innerclasses.MessyClass$InnerClass1");
+    Assertions.assertEquals(14, sc1.getLoc());
 
-		CKClassResult sc2 = report.get("innerclasses.MessyClass$InnerClass2");
-		Assert.assertEquals(9, sc2.getLoc());
+    CKClassResult sc2 = report.get("innerclasses.MessyClass$InnerClass2");
+    Assertions.assertEquals(9, sc2.getLoc());
 
-		CKClassResult an1 = report.get("innerclasses.MessyClass$Anonymous1");
-		Assert.assertEquals(5, an1.getLoc());
-	}
-	
+    CKClassResult an1 = report.get("innerclasses.MessyClass$Anonymous1");
+    Assertions.assertEquals(5, an1.getLoc());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/MethodsDetailsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/MethodsDetailsTest.java
@@ -1,57 +1,57 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-public class MethodsDetailsTest extends BaseTest{
+public class MethodsDetailsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/details-methods");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/details-methods");
+  }
 
-	@Test
-	public void loc() {
-		CKClassResult a = report.get("methods2.A1");
-		Assert.assertEquals(6, a.getMethod("a/0").get().getLoc());
-		Assert.assertEquals(2, a.getMethod("b/0").get().getLoc());
-	}
+  @Test
+  public void loc() {
+    CKClassResult a = report.get("methods2.A1");
+    Assertions.assertEquals(6, a.getMethod("a/0").get().getLoc());
+    Assertions.assertEquals(2, a.getMethod("b/0").get().getLoc());
+  }
 
-	@Test
-	public void parameterQty() {
-		CKClassResult a = report.get("methods2.A1");
-		Assert.assertEquals(3, a.getMethod("c/3[int,int,methods2.A]").get().getParametersQty());
-		Assert.assertEquals(0, a.getMethod("a/0").get().getParametersQty());
-	}
+  @Test
+  public void parameterQty() {
+    CKClassResult a = report.get("methods2.A1");
+    Assertions.assertEquals(3, a.getMethod("c/3[int,int,methods2.A]").get().getParametersQty());
+    Assertions.assertEquals(0, a.getMethod("a/0").get().getParametersQty());
+  }
 
-	@Test
-	public void variableQty() {
-		CKClassResult a = report.get("methods2.A1");
-		Assert.assertEquals(5, a.getMethod("a/0").get().getVariablesQty());
-		Assert.assertEquals(1, a.getMethod("c/3[int,int,methods2.A]").get().getVariablesQty());
-		Assert.assertEquals(0, a.getMethod("b/0").get().getVariablesQty());
-	}
+  @Test
+  public void variableQty() {
+    CKClassResult a = report.get("methods2.A1");
+    Assertions.assertEquals(5, a.getMethod("a/0").get().getVariablesQty());
+    Assertions.assertEquals(1, a.getMethod("c/3[int,int,methods2.A]").get().getVariablesQty());
+    Assertions.assertEquals(0, a.getMethod("b/0").get().getVariablesQty());
+  }
 
-	@Test
-	public void returnQty() {
-		CKClassResult a = report.get("methods2.A1");
-		Assert.assertEquals(0, a.getMethod("c/3[int,int,methods2.A]").get().getReturnQty());
-		Assert.assertEquals(0, a.getMethod("a/0").get().getReturnQty());
-		Assert.assertEquals(3, a.getMethod("d/0").get().getReturnQty());
-		Assert.assertEquals(1, a.getMethod("e/0").get().getReturnQty());
-	}
+  @Test
+  public void returnQty() {
+    CKClassResult a = report.get("methods2.A1");
+    Assertions.assertEquals(0, a.getMethod("c/3[int,int,methods2.A]").get().getReturnQty());
+    Assertions.assertEquals(0, a.getMethod("a/0").get().getReturnQty());
+    Assertions.assertEquals(3, a.getMethod("d/0").get().getReturnQty());
+    Assertions.assertEquals(1, a.getMethod("e/0").get().getReturnQty());
+  }
 
-	@Test
-	public void lineNumber() {
-		CKClassResult a = report.get("methods2.A1");
-		Assert.assertEquals(18, a.getMethod("c/3[int,int,methods2.A]").get().getStartLine());
-		Assert.assertEquals(5, a.getMethod("a/0").get().getStartLine());
-		Assert.assertEquals(22, a.getMethod("d/0").get().getStartLine());
-		Assert.assertEquals(29, a.getMethod("e/0").get().getStartLine());
-	}
+  @Test
+  public void lineNumber() {
+    CKClassResult a = report.get("methods2.A1");
+    Assertions.assertEquals(18, a.getMethod("c/3[int,int,methods2.A]").get().getStartLine());
+    Assertions.assertEquals(5, a.getMethod("a/0").get().getStartLine());
+    Assertions.assertEquals(22, a.getMethod("d/0").get().getStartLine());
+    Assertions.assertEquals(29, a.getMethod("e/0").get().getStartLine());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/MethodsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/MethodsTest.java
@@ -1,114 +1,122 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Optional;
 
 public class MethodsTest extends BaseTest {
 
-    private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-    @BeforeClass
-    public static void setUp() {
-        report = run(fixturesDir() + "/methods");
-    }
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/methods");
+  }
 
-    @Test
-    public void all() {
-        CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(9, a.getNumberOfMethods());
-    }
+  @Test
+  public void all() {
+    CKClassResult a = report.get("methods.Methods");
+    Assertions.assertEquals(9, a.getNumberOfMethods());
+  }
 
-    @Test
-    public void allPublic() {
-        CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(4, a.getNumberOfPublicMethods());
-    }
+  @Test
+  public void allPublic() {
+    CKClassResult a = report.get("methods.Methods");
+    Assertions.assertEquals(4, a.getNumberOfPublicMethods());
+  }
 
-    @Test
-    public void allStatic() {
-        CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(2, a.getNumberOfStaticMethods());
-    }
+  @Test
+  public void allStatic() {
+    CKClassResult a = report.get("methods.Methods");
+    Assertions.assertEquals(2, a.getNumberOfStaticMethods());
+  }
 
-    @Test
-    public void allDefault() {
-        CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(1, a.getNumberOfDefaultMethods());
-    }
+  @Test
+  public void allDefault() {
+    CKClassResult a = report.get("methods.Methods");
+    Assertions.assertEquals(1, a.getNumberOfDefaultMethods());
+  }
 
-    @Test
-    public void allPrivate() {
-        CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(3, a.getNumberOfPrivateMethods());
-    }
+  @Test
+  public void allPrivate() {
+    CKClassResult a = report.get("methods.Methods");
+    Assertions.assertEquals(3, a.getNumberOfPrivateMethods());
+  }
 
-    @Test
-    public void allProtected() {
-        CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(1, a.getNumberOfProtectedMethods());
-    }
+  @Test
+  public void allProtected() {
+    CKClassResult a = report.get("methods.Methods");
+    Assertions.assertEquals(1, a.getNumberOfProtectedMethods());
+  }
 
+  @Test
+  public void allSynchronized() {
+    CKClassResult a = report.get("methods.Methods");
+    Assertions.assertEquals(1, a.getNumberOfSynchronizedMethods());
+  }
 
-    @Test
-    public void allSynchronized() {
-        CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(1, a.getNumberOfSynchronizedMethods());
-    }
+  @Test
+  public void allAbstract() {
+    CKClassResult a = report.get("methods.Methods2");
+    Assertions.assertEquals(3, a.getNumberOfMethods());
+    Assertions.assertEquals(2, a.getNumberOfAbstractMethods());
+  }
 
-    @Test
-    public void allAbstract() {
-        CKClassResult a = report.get("methods.Methods2");
-        Assert.assertEquals(3, a.getNumberOfMethods());
-        Assert.assertEquals(2, a.getNumberOfAbstractMethods());
-    }
+  @Test
+  public void constructors() {
+    CKClassResult a = report.get("methods.Methods3");
+    Assertions.assertEquals(3, a.getNumberOfMethods());
+    Assertions.assertEquals(3, a.getMethods().size());
 
-    @Test
-    public void constructors() {
-        CKClassResult a = report.get("methods.Methods3");
-        Assert.assertEquals(3, a.getNumberOfMethods());
-        Assert.assertEquals(3, a.getMethods().size());
+    CKMethodResult m1 =
+        a.getMethods().stream()
+            .filter(x -> x.getMethodName().equals("Methods3/0"))
+            .findFirst()
+            .get();
+    Assertions.assertTrue(m1.isConstructor());
 
-        CKMethodResult m1 = a.getMethods().stream().filter(x -> x.getMethodName().equals("Methods3/0")).findFirst().get();
-        Assert.assertTrue(m1.isConstructor());
+    CKMethodResult m2 =
+        a.getMethods().stream()
+            .filter(x -> x.getMethodName().equals("Methods3/1[int]"))
+            .findFirst()
+            .get();
+    Assertions.assertTrue(m2.isConstructor());
 
-        CKMethodResult m2 = a.getMethods().stream().filter(x -> x.getMethodName().equals("Methods3/1[int]")).findFirst().get();
-        Assert.assertTrue(m2.isConstructor());
+    CKMethodResult m3 =
+        a.getMethods().stream().filter(x -> x.getMethodName().equals("a/0")).findFirst().get();
+    Assertions.assertFalse(m3.isConstructor());
+  }
 
-        CKMethodResult m3 = a.getMethods().stream().filter(x -> x.getMethodName().equals("a/0")).findFirst().get();
-        Assert.assertFalse(m3.isConstructor());
-    }
+  @Test
+  public void staticInitializer() {
+    CKClassResult a = report.get("methods.StaticInitializer");
 
-    @Test
-    public void staticInitializer() {
-        CKClassResult a = report.get("methods.StaticInitializer");
+    Optional<CKMethodResult> init = a.getMethod("(initializer 1)");
+    Assertions.assertTrue(init.isPresent());
+    Assertions.assertEquals(1, init.get().getLoopQty());
+  }
 
-        Optional<CKMethodResult> init = a.getMethod("(initializer 1)");
-        Assert.assertTrue(init.isPresent());
-        Assert.assertEquals(1, init.get().getLoopQty());
-    }
+  // there can be multiple static initializers in a single class
+  // see https://github.com/mauricioaniche/ck/issues/53
+  @Test
+  public void multipleStaticInitializer() {
+    CKClassResult a = report.get("methods.StaticInitializer2");
 
-    // there can be multiple static initializers in a single class
-    // see https://github.com/mauricioaniche/ck/issues/53
-    @Test
-    public void multipleStaticInitializer() {
-        CKClassResult a = report.get("methods.StaticInitializer2");
+    Optional<CKMethodResult> init1 = a.getMethod("(initializer 1)");
+    Assertions.assertTrue(init1.isPresent());
+    Assertions.assertEquals(1, init1.get().getLoopQty());
 
-        Optional<CKMethodResult> init1 = a.getMethod("(initializer 1)");
-        Assert.assertTrue(init1.isPresent());
-        Assert.assertEquals(1, init1.get().getLoopQty());
+    Optional<CKMethodResult> init2 = a.getMethod("(initializer 2)");
+    Assertions.assertTrue(init2.isPresent());
+    Assertions.assertEquals(0, init2.get().getLoopQty());
+  }
 
-        Optional<CKMethodResult> init2 = a.getMethod("(initializer 2)");
-        Assert.assertTrue(init2.isPresent());
-        Assert.assertEquals(0, init2.get().getLoopQty());
-    }
-
-    @Test
-    public void allFinal() {
-        CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(1, a.getNumberOfFinalMethods());
-    }
+  @Test
+  public void allFinal() {
+    CKClassResult a = report.get("methods.Methods");
+    Assertions.assertEquals(1, a.getNumberOfFinalMethods());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/MetricsPerClassesAndInnerClassesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/MetricsPerClassesAndInnerClassesTest.java
@@ -1,61 +1,61 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class MetricsPerClassesAndInnerClassesTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/innerclasses");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/innerclasses");
+  }
 
-	@Test
-	public void metricsPerClass() {
+  @Test
+  public void metricsPerClass() {
 
-		Assert.assertEquals(9, report.values().size());
+    Assertions.assertEquals(9, report.values().size());
 
-		CKClassResult a = report.get("innerclasses.MessyClass");
-		Assert.assertEquals(6, a.getNumberOfMethods());
-		Assert.assertEquals("class", a.getType());
+    CKClassResult a = report.get("innerclasses.MessyClass");
+    Assertions.assertEquals(6, a.getNumberOfMethods());
+    Assertions.assertEquals("class", a.getType());
 
-		CKClassResult sc1 = report.get("innerclasses.MessyClass$InnerClass1");
-		Assert.assertEquals(2, sc1.getNumberOfMethods());
-		Assert.assertEquals(2, sc1.getMethods().stream().filter(x -> x.getMethodName().equals("m1/0")).findFirst().get().getMaxNestedBlocks());
-		Assert.assertEquals("innerclass", sc1.getType());
+    CKClassResult sc1 = report.get("innerclasses.MessyClass$InnerClass1");
+    Assertions.assertEquals(2, sc1.getNumberOfMethods());
+    Assertions.assertEquals(
+        2,
+        sc1.getMethods().stream()
+            .filter(x -> x.getMethodName().equals("m1/0"))
+            .findFirst()
+            .get()
+            .getMaxNestedBlocks());
+    Assertions.assertEquals("innerclass", sc1.getType());
 
-		CKClassResult sc2 = report.get("innerclasses.MessyClass$InnerClass2");
-		Assert.assertEquals(3, sc2.getNumberOfMethods());
-		Assert.assertEquals("innerclass", sc2.getType());
+    CKClassResult sc2 = report.get("innerclasses.MessyClass$InnerClass2");
+    Assertions.assertEquals(3, sc2.getNumberOfMethods());
+    Assertions.assertEquals("innerclass", sc2.getType());
 
-		CKClassResult sc3 = report.get("innerclasses.MessyClass$1InnerClass3");
-		Assert.assertEquals(1, sc3.getNumberOfMethods());
-		Assert.assertEquals("innerclass", sc3.getType());
+    CKClassResult sc3 = report.get("innerclasses.MessyClass$1InnerClass3");
+    Assertions.assertEquals(1, sc3.getNumberOfMethods());
+    Assertions.assertEquals("innerclass", sc3.getType());
 
-		CKClassResult an1 = report.get("innerclasses.MessyClass$Anonymous1");
-		Assert.assertEquals(1, an1.getNumberOfMethods());
-		Assert.assertEquals("anonymous", an1.getType());
+    CKClassResult an1 = report.get("innerclasses.MessyClass$Anonymous1");
+    Assertions.assertEquals(1, an1.getNumberOfMethods());
+    Assertions.assertEquals("anonymous", an1.getType());
 
-		CKClassResult an2 = report.get("innerclasses.MessyClass$Anonymous2");
-		Assert.assertEquals(2, an2.getNumberOfMethods());
-		Assert.assertEquals("anonymous", an2.getType());
+    CKClassResult an2 = report.get("innerclasses.MessyClass$Anonymous2");
+    Assertions.assertEquals(2, an2.getNumberOfMethods());
+    Assertions.assertEquals("anonymous", an2.getType());
 
-
-		CKClassResult ysc2 = report.get("innerclasses.SC2");
-		Assert.assertEquals("class", ysc2.getType());
-		CKClassResult ysc2a = report.get("innerclasses.SC2$Anonymous1");
-		Assert.assertEquals("anonymous", ysc2a.getType());
-		CKClassResult ysc2x = report.get("innerclasses.SC2$1$1X");
-		Assert.assertEquals("innerclass", ysc2x.getType());
-
-	}
-
-
-
-
+    CKClassResult ysc2 = report.get("innerclasses.SC2");
+    Assertions.assertEquals("class", ysc2.getType());
+    CKClassResult ysc2a = report.get("innerclasses.SC2$Anonymous1");
+    Assertions.assertEquals("anonymous", ysc2a.getType());
+    CKClassResult ysc2x = report.get("innerclasses.SC2$1$1X");
+    Assertions.assertEquals("innerclass", ysc2x.getType());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/ModifiersTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/ModifiersTest.java
@@ -1,53 +1,50 @@
 package com.github.mauricioaniche.ck;
 
-
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import static org.junit.Assert.assertTrue;
-
 import org.eclipse.jdt.core.dom.Modifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ModifiersTest extends BaseTest {
 
+  private static Map<String, CKClassResult> report;
+  private static Map<String, Integer> modifiersByMethod;
+  private static CKClassResult classResult;
 
-	private static Map<String, CKClassResult> report;
-	private static Map<String, Integer> modifiersByMethod;
-	private static CKClassResult classResult;
-	
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/modifiers");
-		classResult = report.get("modifiers.ClassWithModifiers");
-		modifiersByMethod = classResult.getMethods().stream().collect(Collectors.toMap(x -> x.getMethodName(), x->x.getModifiers()));
-	}
-	
-	
-	@Test
-	public void testClassIsAbstract() {
-		assertTrue(Modifier.isAbstract(classResult.getModifiers()));
-	}
-	
-	@Test
-	public void testFinalMethod() {
-		assertTrue(Modifier.isFinal(modifiersByMethod.get("finalMethod/0")));
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/modifiers");
+    classResult = report.get("modifiers.ClassWithModifiers");
+    modifiersByMethod =
+        classResult.getMethods().stream()
+            .collect(Collectors.toMap(CKMethodResult::getMethodName, CKMethodResult::getModifiers));
+  }
 
-	@Test
-	public void testAbstractMethod() {
-		assertTrue(Modifier.isAbstract(modifiersByMethod.get("abstractMethod/0")));
-	}
+  @Test
+  public void testClassIsAbstract() {
+    Assertions.assertTrue(Modifier.isAbstract(classResult.getModifiers()));
+  }
 
-	@Test
-	public void testPrivateMethod() {
-		assertTrue(Modifier.isPrivate(modifiersByMethod.get("privateMethod/0")));
-	}
+  @Test
+  public void testFinalMethod() {
+    Assertions.assertTrue(Modifier.isFinal(modifiersByMethod.get("finalMethod/0")));
+  }
 
-	@Test
-	public void testNativeMethod() {
-		assertTrue(Modifier.isNative(modifiersByMethod.get("nativeRun/0")));
-	}
+  @Test
+  public void testAbstractMethod() {
+    Assertions.assertTrue(Modifier.isAbstract(modifiersByMethod.get("abstractMethod/0")));
+  }
 
+  @Test
+  public void testPrivateMethod() {
+    Assertions.assertTrue(Modifier.isPrivate(modifiersByMethod.get("privateMethod/0")));
+  }
+
+  @Test
+  public void testNativeMethod() {
+    Assertions.assertTrue(Modifier.isNative(modifiersByMethod.get("nativeRun/0")));
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NOSITest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NOSITest.java
@@ -1,35 +1,35 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NOSITest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/nosi");
-	}
-	
-	@Test
-	public void staticInvocations() {
-		CKClassResult a = report.get("nosi.Class2");
-		Assert.assertEquals(1, a.getNosi());
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/nosi");
+  }
 
-	@Test
-	public void staticInvocationsToMethodsInTheSameClass() {
-		CKClassResult a = report.get("nosi.Class3");
-		Assert.assertEquals(2, a.getNosi());
-	}
+  @Test
+  public void staticInvocations() {
+    CKClassResult a = report.get("nosi.Class2");
+    Assertions.assertEquals(1, a.getNosi());
+  }
 
-	@Test
-	public void doesNotUnderstandWhenNotResolvable() {
-		CKClassResult a = report.get("nosi.Class1");
-		Assert.assertEquals(0, a.getNosi());
-	}
+  @Test
+  public void staticInvocationsToMethodsInTheSameClass() {
+    CKClassResult a = report.get("nosi.Class3");
+    Assertions.assertEquals(2, a.getNosi());
+  }
+
+  @Test
+  public void doesNotUnderstandWhenNotResolvable() {
+    CKClassResult a = report.get("nosi.Class1");
+    Assertions.assertEquals(0, a.getNosi());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfAssignmentsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfAssignmentsTest.java
@@ -1,29 +1,28 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfAssignmentsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/assignments");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/assignments");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("assignments.Assignments");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("assignments.Assignments");
 
-		Assert.assertEquals(8, a.getAssignmentsQty());
+    Assertions.assertEquals(8, a.getAssignmentsQty());
 
-		Assert.assertEquals(5, a.getMethod("m1/0").get().getAssignmentsQty());
-		Assert.assertEquals(3, a.getMethod("m2/0").get().getAssignmentsQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getAssignmentsQty());
-
-	}
+    Assertions.assertEquals(5, a.getMethod("m1/0").get().getAssignmentsQty());
+    Assertions.assertEquals(3, a.getMethod("m2/0").get().getAssignmentsQty());
+    Assertions.assertEquals(0, a.getMethod("m3/0").get().getAssignmentsQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfComparisonsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfComparisonsTest.java
@@ -1,30 +1,29 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfComparisonsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/comparison");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/comparison");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("comparison.Comparison");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("comparison.Comparison");
 
-		Assert.assertEquals(4, a.getComparisonsQty());
+    Assertions.assertEquals(4, a.getComparisonsQty());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getComparisonsQty());
-		Assert.assertEquals(1, a.getMethod("m2/0").get().getComparisonsQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getComparisonsQty());
-		Assert.assertEquals(1, a.getMethod("m4/0").get().getComparisonsQty());
-
-	}
+    Assertions.assertEquals(2, a.getMethod("m1/0").get().getComparisonsQty());
+    Assertions.assertEquals(1, a.getMethod("m2/0").get().getComparisonsQty());
+    Assertions.assertEquals(0, a.getMethod("m3/0").get().getComparisonsQty());
+    Assertions.assertEquals(1, a.getMethod("m4/0").get().getComparisonsQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfInnerClassesLambdasAndAnonymousClassesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfInnerClassesLambdasAndAnonymousClassesTest.java
@@ -1,79 +1,79 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfInnerClassesLambdasAndAnonymousClassesTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = runDebug(fixturesDir() + "/innerclasses");
-		report = run(fixturesDir() + "/innerclasses");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = runDebug(fixturesDir() + "/innerclasses");
+    report = run(fixturesDir() + "/innerclasses");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("innerclasses.MessyClass");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("innerclasses.MessyClass");
 
-		Assert.assertEquals(2, a.getAnonymousClassesQty());
-		Assert.assertEquals(1, a.getLambdasQty());
-		Assert.assertEquals(3, a.getInnerClassesQty());
+    Assertions.assertEquals(2, a.getAnonymousClassesQty());
+    Assertions.assertEquals(1, a.getLambdasQty());
+    Assertions.assertEquals(3, a.getInnerClassesQty());
 
-		Assert.assertEquals(0, a.getMethod("m1/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m1/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m1/0").get().getInnerClassesQty());
+    Assertions.assertEquals(0, a.getMethod("m1/0").get().getAnonymousClassesQty());
+    Assertions.assertEquals(0, a.getMethod("m1/0").get().getLambdasQty());
+    Assertions.assertEquals(0, a.getMethod("m1/0").get().getInnerClassesQty());
 
-		Assert.assertEquals(0, a.getMethod("m2/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m2/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m2/0").get().getInnerClassesQty());
+    Assertions.assertEquals(0, a.getMethod("m2/0").get().getAnonymousClassesQty());
+    Assertions.assertEquals(0, a.getMethod("m2/0").get().getLambdasQty());
+    Assertions.assertEquals(0, a.getMethod("m2/0").get().getInnerClassesQty());
 
-		Assert.assertEquals(1, a.getMethod("m3/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getInnerClassesQty());
+    Assertions.assertEquals(1, a.getMethod("m3/0").get().getAnonymousClassesQty());
+    Assertions.assertEquals(0, a.getMethod("m3/0").get().getLambdasQty());
+    Assertions.assertEquals(0, a.getMethod("m3/0").get().getInnerClassesQty());
 
-		Assert.assertEquals(1, a.getMethod("m4/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m4/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m4/0").get().getInnerClassesQty());
+    Assertions.assertEquals(1, a.getMethod("m4/0").get().getLambdasQty());
+    Assertions.assertEquals(0, a.getMethod("m4/0").get().getAnonymousClassesQty());
+    Assertions.assertEquals(0, a.getMethod("m4/0").get().getInnerClassesQty());
 
+    Assertions.assertEquals(1, a.getMethod("m5/0").get().getAnonymousClassesQty());
+    Assertions.assertEquals(0, a.getMethod("m5/0").get().getLambdasQty());
+    Assertions.assertEquals(0, a.getMethod("m5/0").get().getInnerClassesQty());
 
-		Assert.assertEquals(1, a.getMethod("m5/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m5/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m5/0").get().getInnerClassesQty());
+    Assertions.assertEquals(1, a.getMethod("m6/0").get().getInnerClassesQty());
+    Assertions.assertEquals(0, a.getMethod("m6/0").get().getLambdasQty());
+    Assertions.assertEquals(0, a.getMethod("m6/0").get().getAnonymousClassesQty());
+  }
 
-		Assert.assertEquals(1, a.getMethod("m6/0").get().getInnerClassesQty());
-		Assert.assertEquals(0, a.getMethod("m6/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m6/0").get().getAnonymousClassesQty());
-	}
+  @Test
+  public void innerclassesInsideAnonymousClasses() {
 
-	@Test
-	public void innerclassesInsideAnonymousClasses() {
+    System.out.println(report.keySet());
+    CKClassResult a = report.get("innerclasses.SC2");
+    // the innerclass is inside the anonymous method inside the method (two levels below...), and
+    // not the class...
+    Assertions.assertEquals(0, a.getInnerClassesQty());
+    Assertions.assertEquals(1, a.getAnonymousClassesQty());
+    Assertions.assertEquals(0, a.getLambdasQty());
 
-		System.out.println(report.keySet());
-		CKClassResult a = report.get("innerclasses.SC2");
-		// the innerclass is inside the anonymous method inside the method (two levels below...), and not the class...
-		Assert.assertEquals(0, a.getInnerClassesQty());
-		Assert.assertEquals(1, a.getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getLambdasQty());
+    Assertions.assertEquals(1, a.getMethod("m1/0").get().getAnonymousClassesQty());
+    Assertions.assertEquals(0, a.getMethod("m1/0").get().getInnerClassesQty());
+    Assertions.assertEquals(0, a.getMethod("m1/0").get().getLambdasQty());
 
-		Assert.assertEquals(1, a.getMethod("m1/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m1/0").get().getInnerClassesQty());
-		Assert.assertEquals(0, a.getMethod("m1/0").get().getLambdasQty());
+    CKClassResult b = report.get("innerclasses.SC2$Anonymous1");
+    Assertions.assertEquals(1, b.getMethod("toString/0").get().getInnerClassesQty());
+    Assertions.assertEquals(1, b.getInnerClassesQty());
+    Assertions.assertEquals(0, b.getLambdasQty());
+    Assertions.assertEquals(0, b.getAnonymousClassesQty());
 
-		CKClassResult b = report.get("innerclasses.SC2$Anonymous1");
-		Assert.assertEquals(1, b.getMethod("toString/0").get().getInnerClassesQty());
-		Assert.assertEquals(1, b.getInnerClassesQty());
-		Assert.assertEquals(0, b.getLambdasQty());
-		Assert.assertEquals(0, b.getAnonymousClassesQty());
-
-		CKClassResult sc = report.get("innerclasses.SC2$1$1X");
-		Assert.assertNotNull(sc);
-		Assert.assertEquals(0, sc.getInnerClassesQty());
-		Assert.assertEquals(0, sc.getLambdasQty());
-		Assert.assertEquals(0, sc.getAnonymousClassesQty());
-	}
+    CKClassResult sc = report.get("innerclasses.SC2$1$1X");
+    Assertions.assertNotNull(sc);
+    Assertions.assertEquals(0, sc.getInnerClassesQty());
+    Assertions.assertEquals(0, sc.getLambdasQty());
+    Assertions.assertEquals(0, sc.getAnonymousClassesQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfLogStatementsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfLogStatementsTest.java
@@ -1,29 +1,28 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-
 public class NumberOfLogStatementsTest extends BaseTest {
 
-    private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-    @BeforeClass
-    public static void setUp() {
-        report = run(fixturesDir() + "/logs");
-    }
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/logs");
+  }
 
-    @Test
-    public void count() {
-        CKClassResult a = report.get("logs.LogStatements");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("logs.LogStatements");
 
-        assertEquals(4, a.getNumberOfLogStatements());
+    Assertions.assertEquals(4, a.getNumberOfLogStatements());
 
-        assertEquals(1, a.getMethod("m1/0").get().getLogStatementsQty());
-        assertEquals(0, a.getMethod("m2/0").get().getLogStatementsQty());
-        assertEquals(3, a.getMethod("m3/0").get().getLogStatementsQty());
-    }
+    Assertions.assertEquals(1, a.getMethod("m1/0").get().getLogStatementsQty());
+    Assertions.assertEquals(0, a.getMethod("m2/0").get().getLogStatementsQty());
+    Assertions.assertEquals(3, a.getMethod("m3/0").get().getLogStatementsQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfLoopsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfLoopsTest.java
@@ -1,44 +1,42 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfLoopsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/loop");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/loop");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("loop.Loop");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("loop.Loop");
 
-		Assert.assertEquals(5, a.getLoopQty());
+    Assertions.assertEquals(5, a.getLoopQty());
 
-		Assert.assertEquals(1, a.getMethod("m1/0").get().getLoopQty());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getLoopQty());
-		Assert.assertEquals(1, a.getMethod("m3/0").get().getLoopQty());
-		Assert.assertEquals(0, a.getMethod("m4/0").get().getLoopQty());
-		Assert.assertEquals(1, a.getMethod("m5/0").get().getLoopQty());
+    Assertions.assertEquals(1, a.getMethod("m1/0").get().getLoopQty());
+    Assertions.assertEquals(2, a.getMethod("m2/0").get().getLoopQty());
+    Assertions.assertEquals(1, a.getMethod("m3/0").get().getLoopQty());
+    Assertions.assertEquals(0, a.getMethod("m4/0").get().getLoopQty());
+    Assertions.assertEquals(1, a.getMethod("m5/0").get().getLoopQty());
+  }
 
-	}
+  @Test
+  public void infiniteLoops() {
+    CKClassResult a = report.get("loop.Loop2");
 
-	@Test
-	public void infiniteLoops() {
-		CKClassResult a = report.get("loop.Loop2");
-
-		Assert.assertEquals(6, a.getLoopQty());
-		Assert.assertEquals(0, a.getMethod("m0/0").get().getLoopQty());
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getLoopQty());
-		Assert.assertEquals(1, a.getMethod("m2/0").get().getLoopQty());
-		Assert.assertEquals(2, a.getMethod("m3/0").get().getLoopQty());
-		Assert.assertEquals(1, a.getMethod("m4/0").get().getLoopQty());
-
-	}
+    Assertions.assertEquals(6, a.getLoopQty());
+    Assertions.assertEquals(0, a.getMethod("m0/0").get().getLoopQty());
+    Assertions.assertEquals(2, a.getMethod("m1/0").get().getLoopQty());
+    Assertions.assertEquals(1, a.getMethod("m2/0").get().getLoopQty());
+    Assertions.assertEquals(2, a.getMethod("m3/0").get().getLoopQty());
+    Assertions.assertEquals(1, a.getMethod("m4/0").get().getLoopQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfMathOperationsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfMathOperationsTest.java
@@ -1,29 +1,28 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfMathOperationsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/math");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/math");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("math.Math");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("math.Math");
 
-		Assert.assertEquals(5, a.getMathOperationsQty());
+    Assertions.assertEquals(5, a.getMathOperationsQty());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getMathOperationsQty());
-		Assert.assertEquals(3, a.getMethod("m2/0").get().getMathOperationsQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getMathOperationsQty());
-
-	}
+    Assertions.assertEquals(2, a.getMethod("m1/0").get().getMathOperationsQty());
+    Assertions.assertEquals(3, a.getMethod("m2/0").get().getMathOperationsQty());
+    Assertions.assertEquals(0, a.getMethod("m3/0").get().getMathOperationsQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfMaxNestedBlocksTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfMaxNestedBlocksTest.java
@@ -1,105 +1,103 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfMaxNestedBlocksTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/nestedblocks");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/nestedblocks");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("nestedblocks.NestedBlocks");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("nestedblocks.NestedBlocks");
 
-		Assert.assertEquals(5, a.getMaxNestedBlocks());
+    Assertions.assertEquals(5, a.getMaxNestedBlocks());
 
-		Assert.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getMaxNestedBlocks());
-	}
+    Assertions.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(2, a.getMethod("m2/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(0, a.getMethod("m3/0").get().getMaxNestedBlocks());
+  }
 
-	@Test
-	public void blocksWithNoClearOpenBracket() {
-		CKClassResult a = report.get("nestedblocks.NestedBlocks2");
+  @Test
+  public void blocksWithNoClearOpenBracket() {
+    CKClassResult a = report.get("nestedblocks.NestedBlocks2");
 
-		Assert.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(2, a.getMethod("m2/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(0, a.getMethod("m3/0").get().getMaxNestedBlocks());
 
-		Assert.assertEquals(5, a.getMaxNestedBlocks());
-	}
+    Assertions.assertEquals(5, a.getMaxNestedBlocks());
+  }
 
-	@Test
-	public void loops() {
-		CKClassResult a = report.get("nestedblocks.NestedBlocks3");
+  @Test
+  public void loops() {
+    CKClassResult a = report.get("nestedblocks.NestedBlocks3");
 
-		Assert.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
 
-		Assert.assertEquals(5, a.getMaxNestedBlocks());
-	}
+    Assertions.assertEquals(5, a.getMaxNestedBlocks());
+  }
 
-	@Test
-	public void switchCases() {
-		CKClassResult a = report.get("nestedblocks.NestedBlocks4");
+  @Test
+  public void switchCases() {
+    CKClassResult a = report.get("nestedblocks.NestedBlocks4");
 
-		Assert.assertEquals(4, a.getMethod("m1/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(4, a.getMethod("m2/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(4, a.getMethod("m1/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(4, a.getMethod("m2/0").get().getMaxNestedBlocks());
 
-		Assert.assertEquals(4, a.getMaxNestedBlocks());
-	}
+    Assertions.assertEquals(4, a.getMaxNestedBlocks());
+  }
 
-	@Test
-	public void blocksJustBecause() {
-		CKClassResult a = report.get("nestedblocks.NestedBlocks5");
+  @Test
+  public void blocksJustBecause() {
+    CKClassResult a = report.get("nestedblocks.NestedBlocks5");
 
-		Assert.assertEquals(3, a.getMethod("m1/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(3, a.getMethod("m1/0").get().getMaxNestedBlocks());
 
-		Assert.assertEquals(3, a.getMaxNestedBlocks());
-	}
+    Assertions.assertEquals(3, a.getMaxNestedBlocks());
+  }
 
-	@Test
-	public void tryCatch() {
-		CKClassResult a = report.get("nestedblocks.NestedBlocks6");
+  @Test
+  public void tryCatch() {
+    CKClassResult a = report.get("nestedblocks.NestedBlocks6");
 
-		Assert.assertEquals(3, a.getMethod("m1/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(6, a.getMethod("m2/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(3, a.getMethod("m1/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(6, a.getMethod("m2/0").get().getMaxNestedBlocks());
 
+    Assertions.assertEquals(6, a.getMaxNestedBlocks());
+  }
 
-		Assert.assertEquals(6, a.getMaxNestedBlocks());
-	}
+  @Test
+  public void useSynchronized() {
+    CKClassResult a = report.get("nestedblocks.NestedBlocks7");
 
-	@Test
-	public void useSynchronized() {
-		CKClassResult a = report.get("nestedblocks.NestedBlocks7");
+    Assertions.assertEquals(2, a.getMethod("m1/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(2, a.getMethod("m1/0").get().getMaxNestedBlocks());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getMaxNestedBlocks());
+    Assertions.assertEquals(2, a.getMaxNestedBlocks());
+  }
 
+  // Basic enums do not have nested blocks
+  @Test
+  public void enums() {
+    CKClassResult a = report.get("nestedblocks.SimpleEnum");
 
-		Assert.assertEquals(2, a.getMaxNestedBlocks());
-	}
+    Assertions.assertEquals(0, a.getMaxNestedBlocks());
+  }
 
-	// Basic enums do not have nested blocks
-	@Test
-	public void enums() {
-		CKClassResult a = report.get("nestedblocks.SimpleEnum");
+  // based on issue #40
+  @Test
+  public void classesWithNoMethods() {
+    CKClassResult a = report.get("nestedblocks.NestedBlocks8");
 
-		Assert.assertEquals(0, a.getMaxNestedBlocks());
-	}
-
-	// based on issue #40
-	@Test
-	public void classesWithNoMethods() {
-		CKClassResult a = report.get("nestedblocks.NestedBlocks8");
-
-		Assert.assertEquals(0, a.getMaxNestedBlocks());
-	}
+    Assertions.assertEquals(0, a.getMaxNestedBlocks());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfNumbersTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfNumbersTest.java
@@ -1,28 +1,27 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfNumbersTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/numbers");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/numbers");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("numbers.Numbers");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("numbers.Numbers");
 
-		Assert.assertEquals(5, a.getNumbersQty());
+    Assertions.assertEquals(5, a.getNumbersQty());
 
-		Assert.assertEquals(5, a.getMethod("m1/0").get().getNumbersQty());
-		Assert.assertEquals(0, a.getMethod("m2/0").get().getNumbersQty());
-
-	}
+    Assertions.assertEquals(5, a.getMethod("m1/0").get().getNumbersQty());
+    Assertions.assertEquals(0, a.getMethod("m2/0").get().getNumbersQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfReturnsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfReturnsTest.java
@@ -1,30 +1,29 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfReturnsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/returns");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/returns");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("returns.Returns");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("returns.Returns");
 
-		Assert.assertEquals(6, a.getReturnQty());
+    Assertions.assertEquals(6, a.getReturnQty());
 
-		Assert.assertEquals(3, a.getMethod("m1/0").get().getReturnQty());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getReturnQty());
-		Assert.assertEquals(1, a.getMethod("m3/0").get().getReturnQty());
-		Assert.assertEquals(0, a.getMethod("m4/0").get().getReturnQty());
-
-	}
+    Assertions.assertEquals(3, a.getMethod("m1/0").get().getReturnQty());
+    Assertions.assertEquals(2, a.getMethod("m2/0").get().getReturnQty());
+    Assertions.assertEquals(1, a.getMethod("m3/0").get().getReturnQty());
+    Assertions.assertEquals(0, a.getMethod("m4/0").get().getReturnQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfStringsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfStringsTest.java
@@ -1,29 +1,28 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfStringsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/strings");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/strings");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("strings.Strings");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("strings.Strings");
 
-		Assert.assertEquals(4, a.getStringLiteralsQty());
+    Assertions.assertEquals(4, a.getStringLiteralsQty());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getStringLiteralsQty());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getStringLiteralsQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getStringLiteralsQty());
-
-	}
+    Assertions.assertEquals(2, a.getMethod("m1/0").get().getStringLiteralsQty());
+    Assertions.assertEquals(2, a.getMethod("m2/0").get().getStringLiteralsQty());
+    Assertions.assertEquals(0, a.getMethod("m3/0").get().getStringLiteralsQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfTryCatchesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfTryCatchesTest.java
@@ -1,30 +1,29 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfTryCatchesTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/trycatch");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/trycatch");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("trycatch.TryCatch");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("trycatch.TryCatch");
 
-		Assert.assertEquals(4, a.getTryCatchQty());
+    Assertions.assertEquals(4, a.getTryCatchQty());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getTryCatchQty());
-		Assert.assertEquals(1, a.getMethod("m2/0").get().getTryCatchQty());
-		Assert.assertEquals(1, a.getMethod("m3/0").get().getTryCatchQty());
-		Assert.assertEquals(0, a.getMethod("m4/0").get().getTryCatchQty());
-
-	}
+    Assertions.assertEquals(2, a.getMethod("m1/0").get().getTryCatchQty());
+    Assertions.assertEquals(1, a.getMethod("m2/0").get().getTryCatchQty());
+    Assertions.assertEquals(1, a.getMethod("m3/0").get().getTryCatchQty());
+    Assertions.assertEquals(0, a.getMethod("m4/0").get().getTryCatchQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfVariablesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfVariablesTest.java
@@ -1,29 +1,28 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class NumberOfVariablesTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/variables");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/variables");
+  }
 
-	@Test
-	public void count() {
-		CKClassResult a = report.get("variables.Variables");
+  @Test
+  public void count() {
+    CKClassResult a = report.get("variables.Variables");
 
-		Assert.assertEquals(8, a.getVariablesQty());
+    Assertions.assertEquals(8, a.getVariablesQty());
 
-		Assert.assertEquals(4, a.getMethod("m1/0").get().getVariablesQty());
-		Assert.assertEquals(4, a.getMethod("m2/0").get().getVariablesQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getVariablesQty());
-
-	}
+    Assertions.assertEquals(4, a.getMethod("m1/0").get().getVariablesQty());
+    Assertions.assertEquals(4, a.getMethod("m2/0").get().getVariablesQty());
+    Assertions.assertEquals(0, a.getMethod("m3/0").get().getVariablesQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/ParametersTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/ParametersTest.java
@@ -1,26 +1,27 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
-
 public class ParametersTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/parameters");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/parameters");
+  }
 
-	@Test
-	public void testSignatureResolution() {
-		assertTrue(this.report.containsKey("A"));
-		CKClassResult clazz = this.report.get("A");
-		assertTrue(clazz.getMethod("m1/6[pac.B,pac.B,Missing,pac.Missing,Missing2,pacmissing.Missing2]").isPresent());
-	}
-
+  @Test
+  public void testSignatureResolution() {
+    Assertions.assertTrue(report.containsKey("A"));
+    CKClassResult clazz = report.get("A");
+    Assertions.assertTrue(
+        clazz
+            .getMethod("m1/6[pac.B,pac.B,Missing,pac.Missing,Missing2,pacmissing.Missing2]")
+            .isPresent());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/RFCTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/RFCTest.java
@@ -1,11 +1,10 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.util.Map;
 
+@DisplayName("RFC tests")
 public class RFCTest extends BaseTest {
 
   private static Map<String, CKClassResult> report;
@@ -16,30 +15,14 @@ public class RFCTest extends BaseTest {
   }
 
   @Test
+  @DisplayName("Count the number of methods invocations")
   public void countMethodInvocations() {
     CKClassResult a = report.get("rfc.GO");
     Assertions.assertEquals(3, a.getRfc());
   }
 
   @Test
-  public void countSuperInvocations() {
-    CKClassResult a = report.get("rfc.GO3");
-    Assertions.assertEquals(2, a.getRfc());
-  }
-
-  @Test
-  public void notPossibleToDifferentiateTypesWithStaticAnalysis() {
-    CKClassResult a = report.get("rfc.RFC3");
-    Assertions.assertEquals(1, a.getRfc());
-  }
-
-  @Test
-  public void doesNotCountConstructorInvocations() {
-    CKClassResult a = report.get("rfc.RFC2");
-    Assertions.assertEquals(0, a.getRfc());
-  }
-
-  @Test
+  @DisplayName("Count the number of methods invocations at method level")
   public void methodLevel() {
     CKClassResult a = report.get("rfc.GO");
     Assertions.assertEquals(2, a.getMethod("m1/0").get().getRfc());
@@ -48,14 +31,54 @@ public class RFCTest extends BaseTest {
   }
 
   @Test
+  @DisplayName("Count the number of super methods invocations")
+  public void countSuperInvocations() {
+    CKClassResult a = report.get("rfc.GO3");
+    Assertions.assertEquals(2, a.getRfc());
+  }
+
+  @Test
+  @Disabled
+  @DisplayName("It isn't possible differentiate types with status analysis")
+  public void notPossibleToDifferentiateTypesWithStaticAnalysis() {
+    CKClassResult a = report.get("rfc.RFC3");
+    Assertions.assertEquals(2, a.getRfc());
+  }
+
+  @Test
+  @DisplayName("Shouldn't count constructor invocations")
+  public void doesNotCountConstructorInvocations() {
+    CKClassResult a = report.get("rfc.RFC2");
+    Assertions.assertEquals(0, a.getRfc());
+  }
+
+  @Test
+  @DisplayName("No method invocation")
   public void noMethodInvocation() {
     CKClassResult a = report.get("rfc.RFC4");
     Assertions.assertEquals(0, a.getRfc());
   }
 
+  //  TODO Should be 2 method invocations, "fobj.dummyFun(5);" and "z()"
   @Test
+  @DisplayName("Count the number of functional method invocation")
   public void functionalInterface() {
     CKClassResult a = report.get("rfc.RFC5");
     Assertions.assertEquals(3, a.getRfc());
+  }
+
+  @Test
+  @DisplayName("Count the number of method invocations in a build class")
+  public void test1() {
+    CKClassResult a = report.get("rfc.RFC6");
+    Assertions.assertEquals(4, a.getRfc());
+  }
+
+  @Test
+  @DisplayName("Count the number of method invocations in a stream")
+  public void test2() {
+    CKClassResult a = report.get("rfc.RFC7");
+    Assertions.assertEquals(5, a.getMethod("m1/0").get().getRfc());
+    Assertions.assertEquals(7, a.getMethod("m2/0").get().getRfc());
   }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/RFCTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/RFCTest.java
@@ -68,17 +68,17 @@ public class RFCTest extends BaseTest {
   }
 
   @Test
-  @DisplayName("Count the number of method invocations in a build class")
+  @DisplayName("Count the number of method invocations in a sequence of calls")
   public void test1() {
     CKClassResult a = report.get("rfc.RFC6");
     Assertions.assertEquals(4, a.getRfc());
   }
 
   @Test
-  @DisplayName("Count the number of method invocations in a stream")
+  @DisplayName("Count the number of method reference invocations")
   public void test2() {
     CKClassResult a = report.get("rfc.RFC7");
     Assertions.assertEquals(5, a.getMethod("m1/0").get().getRfc());
-    Assertions.assertEquals(7, a.getMethod("m2/0").get().getRfc());
+    Assertions.assertEquals(8, a.getMethod("m2/0").get().getRfc());
   }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/RFCTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/RFCTest.java
@@ -1,64 +1,61 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class RFCTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/rfc");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/rfc");
+  }
 
-	@Test
-	public void countMethodInvocations() {
-		CKClassResult a = report.get("rfc.GO");
-		Assert.assertEquals(3, a.getRfc());
-	}
+  @Test
+  public void countMethodInvocations() {
+    CKClassResult a = report.get("rfc.GO");
+    Assertions.assertEquals(3, a.getRfc());
+  }
 
-	@Test
-	public void countSuperInvocations() {
-		CKClassResult a = report.get("rfc.GO3");
-		Assert.assertEquals(2, a.getRfc());
-	}
+  @Test
+  public void countSuperInvocations() {
+    CKClassResult a = report.get("rfc.GO3");
+    Assertions.assertEquals(2, a.getRfc());
+  }
 
-	@Test
-	public void notPossibleToDifferentiateTypesWithStaticAnalysis() {
-		CKClassResult a = report.get("rfc.RFC3");
-		Assert.assertEquals(1, a.getRfc());
-	}
+  @Test
+  public void notPossibleToDifferentiateTypesWithStaticAnalysis() {
+    CKClassResult a = report.get("rfc.RFC3");
+    Assertions.assertEquals(1, a.getRfc());
+  }
 
-	@Test
-	public void doesNotCountConstructorInvocations() {
-		CKClassResult a = report.get("rfc.RFC2");
-		Assert.assertEquals(0, a.getRfc());
-	}
+  @Test
+  public void doesNotCountConstructorInvocations() {
+    CKClassResult a = report.get("rfc.RFC2");
+    Assertions.assertEquals(0, a.getRfc());
+  }
 
-	@Test
-	public void methodLevel() {
-		CKClassResult a = report.get("rfc.GO");
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getRfc());
-		Assert.assertEquals(0, a.getMethod("m2/1[int]").get().getRfc());
-		Assert.assertEquals(1, a.getMethod("m3/0").get().getRfc());
+  @Test
+  public void methodLevel() {
+    CKClassResult a = report.get("rfc.GO");
+    Assertions.assertEquals(2, a.getMethod("m1/0").get().getRfc());
+    Assertions.assertEquals(0, a.getMethod("m2/1[int]").get().getRfc());
+    Assertions.assertEquals(1, a.getMethod("m3/0").get().getRfc());
+  }
 
-	}
+  @Test
+  public void noMethodInvocation() {
+    CKClassResult a = report.get("rfc.RFC4");
+    Assertions.assertEquals(0, a.getRfc());
+  }
 
-	@Test
-	public void noMethodInvocation(){
-		CKClassResult a = report.get("rfc.RFC4");
-		Assert.assertEquals(0, a.getRfc());
-	}
-
-	@Test
-	public void functionalInterface(){
-		CKClassResult a = report.get("rfc.RFC5");
-		Assert.assertEquals(3, a.getRfc());
-
-	}
-
+  @Test
+  public void functionalInterface() {
+    CKClassResult a = report.get("rfc.RFC5");
+    Assertions.assertEquals(3, a.getRfc());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/VariableOrParameterUsageCountTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/VariableOrParameterUsageCountTest.java
@@ -1,57 +1,56 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Map;
 
-public class VariableOrParameterUsageCountTest extends BaseTest{
+public class VariableOrParameterUsageCountTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/parametercount");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/parametercount");
+  }
 
-	@Test
-	public void justDeclaration() {
-		CKClassResult a = report.get("pcount.A");
-		Map<String, Integer> variablesUsageA = a.getMethod("a/0").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(0), variablesUsageA.get("a"));
-		Assert.assertEquals(Integer.valueOf(0), variablesUsageA.get("b"));
-	}
+  @Test
+  public void justDeclaration() {
+    CKClassResult a = report.get("pcount.A");
+    Map<String, Integer> variablesUsageA = a.getMethod("a/0").get().getVariablesUsage();
+    Assertions.assertEquals(Integer.valueOf(0), variablesUsageA.get("a"));
+    Assertions.assertEquals(Integer.valueOf(0), variablesUsageA.get("b"));
+  }
 
-	@Test
-	public void normalUse() {
-		CKClassResult a = report.get("pcount.A");
-		Map<String, Integer> variablesUsageA = a.getMethod("b/0").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(4), variablesUsageA.get("a")); // a appears 5 times
-		Assert.assertEquals(Integer.valueOf(2), variablesUsageA.get("b"));
-	}
+  @Test
+  public void normalUse() {
+    CKClassResult a = report.get("pcount.A");
+    Map<String, Integer> variablesUsageA = a.getMethod("b/0").get().getVariablesUsage();
+    Assertions.assertEquals(Integer.valueOf(4), variablesUsageA.get("a")); // a appears 5 times
+    Assertions.assertEquals(Integer.valueOf(2), variablesUsageA.get("b"));
+  }
 
-	@Test
-	public void passingVariableToMethod() {
-		CKClassResult a = report.get("pcount.A");
-		Map<String, Integer> variablesUsageA = a.getMethod("bb/0").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(1), variablesUsageA.get("a"));
-	}
+  @Test
+  public void passingVariableToMethod() {
+    CKClassResult a = report.get("pcount.A");
+    Map<String, Integer> variablesUsageA = a.getMethod("bb/0").get().getVariablesUsage();
+    Assertions.assertEquals(Integer.valueOf(1), variablesUsageA.get("a"));
+  }
 
-	@Test
-	public void methodParameters() {
-		CKClassResult a = report.get("pcount.A");
-		Map<String, Integer> variablesUsageA = a.getMethod("c/1[int]").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(0), variablesUsageA.get("a"));
+  @Test
+  public void methodParameters() {
+    CKClassResult a = report.get("pcount.A");
+    Map<String, Integer> variablesUsageA = a.getMethod("c/1[int]").get().getVariablesUsage();
+    Assertions.assertEquals(Integer.valueOf(0), variablesUsageA.get("a"));
 
-		Map<String, Integer> variablesUsageB = a.getMethod("d/2[int,int]").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(4), variablesUsageB.get("a"));
-		Assert.assertEquals(Integer.valueOf(0), variablesUsageB.get("b"));
+    Map<String, Integer> variablesUsageB = a.getMethod("d/2[int,int]").get().getVariablesUsage();
+    Assertions.assertEquals(Integer.valueOf(4), variablesUsageB.get("a"));
+    Assertions.assertEquals(Integer.valueOf(0), variablesUsageB.get("b"));
 
-		Map<String, Integer> variablesUsageC = a.getMethod("e/2[pcount.B,int]").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(2), variablesUsageC.get("a"));
-		Assert.assertEquals(Integer.valueOf(0), variablesUsageC.get("b"));
-
-	}
-
+    Map<String, Integer> variablesUsageC =
+        a.getMethod("e/2[pcount.B,int]").get().getVariablesUsage();
+    Assertions.assertEquals(Integer.valueOf(2), variablesUsageC.get("a"));
+    Assertions.assertEquals(Integer.valueOf(0), variablesUsageC.get("b"));
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/WMCTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/WMCTest.java
@@ -1,111 +1,110 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class WMCTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/wmc");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/wmc");
+  }
 
-	@Test
-	public void someOldRandomTests() {
+  @Test
+  public void someOldRandomTests() {
 
-		CKClassResult a = report.get("wmc.CC1");
-		CKClassResult b = report.get("wmc.CC2");
-		CKClassResult c = report.get("wmc.CC3");
+    CKClassResult a = report.get("wmc.CC1");
+    CKClassResult b = report.get("wmc.CC2");
+    CKClassResult c = report.get("wmc.CC3");
 
-		Assert.assertEquals(4, a.getWmc());
-		Assert.assertEquals(6, b.getWmc());
-		Assert.assertEquals(11, c.getWmc());
+    Assertions.assertEquals(4, a.getWmc());
+    Assertions.assertEquals(6, b.getWmc());
+    Assertions.assertEquals(11, c.getWmc());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getWmc());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getWmc());
-		Assert.assertEquals(3, b.getMethod("m1/0").get().getWmc());
-		Assert.assertEquals(3, b.getMethod("m2/0").get().getWmc());
-		Assert.assertEquals(11, c.getMethod("m1/0").get().getWmc());
-	}
+    Assertions.assertEquals(2, a.getMethod("m1/0").get().getWmc());
+    Assertions.assertEquals(2, a.getMethod("m2/0").get().getWmc());
+    Assertions.assertEquals(3, b.getMethod("m1/0").get().getWmc());
+    Assertions.assertEquals(3, b.getMethod("m2/0").get().getWmc());
+    Assertions.assertEquals(11, c.getMethod("m1/0").get().getWmc());
+  }
 
-	@Test
-	public void doNotCountSubClassesCode() {
-		CKClassResult c = report.get("wmc.CC4");
-		Assert.assertEquals(11, c.getMethod("m1/0").get().getWmc());
-		Assert.assertEquals(11, c.getWmc());
+  @Test
+  public void doNotCountSubClassesCode() {
+    CKClassResult c = report.get("wmc.CC4");
+    Assertions.assertEquals(11, c.getMethod("m1/0").get().getWmc());
+    Assertions.assertEquals(11, c.getWmc());
 
-		CKClassResult c2 = report.get("wmc.CC4$1MethodInner");
-		Assert.assertEquals(3, c2.getMethod("print/0").get().getWmc());
-	}
+    CKClassResult c2 = report.get("wmc.CC4$1MethodInner");
+    Assertions.assertEquals(3, c2.getMethod("print/0").get().getWmc());
+  }
 
-	// related to issue #31
-	// note that, although m1 and m2 are semantically similar, their WMC are currently differently.
-	// it would need some smarter analysis to figure out that the complexity of the boolean variable was
-	// already measured before.
-	@Test
-	public void inlineConditions() {
-		CKClassResult c = report.get("wmc.CC6");
-		Assert.assertEquals(7, c.getWmc());
+  // related to issue #31
+  // note that, although m1 and m2 are semantically similar, their WMC are currently differently.
+  // it would need some smarter analysis to figure out that the complexity of the boolean variable
+  // was
+  // already measured before.
+  @Test
+  public void inlineConditions() {
+    CKClassResult c = report.get("wmc.CC6");
+    Assertions.assertEquals(7, c.getWmc());
 
-		Assert.assertEquals(3, c.getMethod("m1/1[int]").get().getWmc());
-		Assert.assertEquals(4, c.getMethod("m2/1[int]").get().getWmc());
-	}
+    Assertions.assertEquals(3, c.getMethod("m1/1[int]").get().getWmc());
+    Assertions.assertEquals(4, c.getMethod("m2/1[int]").get().getWmc());
+  }
 
-	@Test
-	public void straightBooleanComparison() {
-		CKClassResult c = report.get("wmc.CC7");
+  @Test
+  public void straightBooleanComparison() {
+    CKClassResult c = report.get("wmc.CC7");
 
-		Assert.assertEquals(2, c.getMethod("m2/1[boolean]").get().getWmc());
-		Assert.assertEquals(2, c.getMethod("m1/1[boolean]").get().getWmc());
-	}
+    Assertions.assertEquals(2, c.getMethod("m2/1[boolean]").get().getWmc());
+    Assertions.assertEquals(2, c.getMethod("m1/1[boolean]").get().getWmc());
+  }
 
-	@Test
-	public void loops() {
+  @Test
+  public void loops() {
 
-		CKClassResult c = report.get("wmc.CC8");
+    CKClassResult c = report.get("wmc.CC8");
 
-		Assert.assertEquals(3, c.getMethod("m0/0").get().getWmc());
-		Assert.assertEquals(6, c.getMethod("m1/0").get().getWmc());
-		Assert.assertEquals(6, c.getMethod("m2/0").get().getWmc());
-		Assert.assertEquals(6, c.getMethod("m3/0").get().getWmc());
-		Assert.assertEquals(2, c.getMethod("m4/0").get().getWmc());
-		Assert.assertEquals(3, c.getMethod("m5/0").get().getWmc());
-		Assert.assertEquals(6, c.getMethod("m6/0").get().getWmc());
+    Assertions.assertEquals(3, c.getMethod("m0/0").get().getWmc());
+    Assertions.assertEquals(6, c.getMethod("m1/0").get().getWmc());
+    Assertions.assertEquals(6, c.getMethod("m2/0").get().getWmc());
+    Assertions.assertEquals(6, c.getMethod("m3/0").get().getWmc());
+    Assertions.assertEquals(2, c.getMethod("m4/0").get().getWmc());
+    Assertions.assertEquals(3, c.getMethod("m5/0").get().getWmc());
+    Assertions.assertEquals(6, c.getMethod("m6/0").get().getWmc());
 
-		Assert.assertEquals(3+6+6+6+2+3+6, c.getWmc());
+    Assertions.assertEquals(3 + 6 + 6 + 6 + 2 + 3 + 6, c.getWmc());
+  }
 
-	}
+  @Test
+  public void ifs() {
 
-	@Test
-	public void ifs() {
+    CKClassResult c = report.get("wmc.CC9");
 
-		CKClassResult c = report.get("wmc.CC9");
+    Assertions.assertEquals(1, c.getMethod("m0/0").get().getWmc());
+    Assertions.assertEquals(2, c.getMethod("m1/0").get().getWmc());
+    Assertions.assertEquals(3, c.getMethod("m2/0").get().getWmc());
+    Assertions.assertEquals(2, c.getMethod("m3/0").get().getWmc());
+    Assertions.assertEquals(4, c.getMethod("m4/0").get().getWmc());
+    Assertions.assertEquals(8, c.getMethod("m5/0").get().getWmc());
+    Assertions.assertEquals(9, c.getMethod("m6/0").get().getWmc());
+    Assertions.assertEquals(5, c.getMethod("m7/0").get().getWmc());
+    Assertions.assertEquals(4, c.getMethod("m8/0").get().getWmc());
+    Assertions.assertEquals(8, c.getMethod("m9/0").get().getWmc());
 
-		Assert.assertEquals(1, c.getMethod("m0/0").get().getWmc());
-		Assert.assertEquals(2, c.getMethod("m1/0").get().getWmc());
-		Assert.assertEquals(3, c.getMethod("m2/0").get().getWmc());
-		Assert.assertEquals(2, c.getMethod("m3/0").get().getWmc());
-		Assert.assertEquals(4, c.getMethod("m4/0").get().getWmc());
-		Assert.assertEquals(8, c.getMethod("m5/0").get().getWmc());
-		Assert.assertEquals(9, c.getMethod("m6/0").get().getWmc());
-		Assert.assertEquals(5, c.getMethod("m7/0").get().getWmc());
-		Assert.assertEquals(4, c.getMethod("m8/0").get().getWmc());
-		Assert.assertEquals(8, c.getMethod("m9/0").get().getWmc());
+    // the final 2 is for the two other util methods we have there
+    Assertions.assertEquals(1 + 2 + 3 + 2 + 4 + 8 + 9 + 5 + 4 + 8 + 2, c.getWmc());
+  }
 
-		// the final 2 is for the two other util methods we have there
-		Assert.assertEquals(1+2+3+2+4+8+9+5+4+8 + 2, c.getWmc());
-
-	}
-
-	@Test
-	public void nested() {
-		CKClassResult c = report.get("wmc.CC10");
-		Assert.assertEquals(9, c.getMethod("m2/0").get().getWmc());
-		Assert.assertEquals(12, c.getMethod("m1/0").get().getWmc());
-	}
+  @Test
+  public void nested() {
+    CKClassResult c = report.get("wmc.CC10");
+    Assertions.assertEquals(9, c.getMethod("m2/0").get().getWmc());
+    Assertions.assertEquals(12, c.getMethod("m1/0").get().getWmc());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/WordCountsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/WordCountsTest.java
@@ -1,64 +1,64 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class WordCountsTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
-	private CKClassResult w1;
-	private CKClassResult w2;
-	private CKClassResult w3;
+  private static Map<String, CKClassResult> report;
+  private CKClassResult w1;
+  private CKClassResult w2;
+  private CKClassResult w3;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/wordcounts");
-	}
-	
-	@Before
-	public void getClasses() {
-		this.w1 = report.get("wordcounts.WordCounts");
-		this.w2 = report.get("wordcounts.WordCounts2");
-		this.w3 = report.get("wordcounts.WordCounts3");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/wordcounts");
+  }
 
-	@Test
-	public void count() {
-		Assert.assertEquals(1, w1.getMethod("m1/0").get().getUniqueWordsQty());
-		Assert.assertEquals(7, w1.getMethod("m2/0").get().getUniqueWordsQty());
-	}
+  @BeforeEach
+  public void getClasses() {
+    this.w1 = report.get("wordcounts.WordCounts");
+    this.w2 = report.get("wordcounts.WordCounts2");
+    this.w3 = report.get("wordcounts.WordCounts3");
+  }
 
-	// related to issue #33
-	@Test
-	public void countStaticInitializer() {
-		Assert.assertEquals(1, w2.getMethod("m1/0").get().getUniqueWordsQty());
-		Assert.assertEquals(7, w2.getMethod("m2/0").get().getUniqueWordsQty());
-		Assert.assertEquals(3, w2.getMethod("(initializer 1)").get().getUniqueWordsQty());
-	}
+  @Test
+  public void count() {
+    Assertions.assertEquals(1, w1.getMethod("m1/0").get().getUniqueWordsQty());
+    Assertions.assertEquals(7, w1.getMethod("m2/0").get().getUniqueWordsQty());
+  }
 
-	@Test
-	public void countAtClassLevel() {
-		Assert.assertEquals(10, w1.getUniqueWordsQty());
-		Assert.assertEquals(13, w2.getUniqueWordsQty());
-	}
+  // related to issue #33
+  @Test
+  public void countStaticInitializer() {
+    Assertions.assertEquals(1, w2.getMethod("m1/0").get().getUniqueWordsQty());
+    Assertions.assertEquals(7, w2.getMethod("m2/0").get().getUniqueWordsQty());
+    Assertions.assertEquals(3, w2.getMethod("(initializer 1)").get().getUniqueWordsQty());
+  }
 
-	// related to issue #34
-	@Test
-	public void subclasses() {
-		Assert.assertEquals(7, w3.getMethod("m2/0").get().getUniqueWordsQty());
-		Assert.assertEquals(10, w3.getUniqueWordsQty());
+  @Test
+  public void countAtClassLevel() {
+    Assertions.assertEquals(10, w1.getUniqueWordsQty());
+    Assertions.assertEquals(13, w2.getUniqueWordsQty());
+  }
 
-		// numbers in the subclass
-		CKClassResult subclass = report.get("wordcounts.WordCounts3$1X");
-		Assert.assertEquals(3, subclass.getMethod("xxx/0").get().getUniqueWordsQty());
-		Assert.assertEquals(4, subclass.getUniqueWordsQty());
+  // related to issue #34
+  @Test
+  public void subclasses() {
+    Assertions.assertEquals(7, w3.getMethod("m2/0").get().getUniqueWordsQty());
+    Assertions.assertEquals(10, w3.getUniqueWordsQty());
 
-		CKClassResult subclass2 = report.get("wordcounts.WordCounts3$Y");
-		Assert.assertEquals(2, subclass2.getMethod("yyy/0").get().getUniqueWordsQty());
-		Assert.assertEquals(3, subclass2.getUniqueWordsQty());
-	}
+    // numbers in the subclass
+    CKClassResult subclass = report.get("wordcounts.WordCounts3$1X");
+    Assertions.assertEquals(3, subclass.getMethod("xxx/0").get().getUniqueWordsQty());
+    Assertions.assertEquals(4, subclass.getUniqueWordsQty());
+
+    CKClassResult subclass2 = report.get("wordcounts.WordCounts3$Y");
+    Assertions.assertEquals(2, subclass2.getMethod("yyy/0").get().getUniqueWordsQty());
+    Assertions.assertEquals(3, subclass2.getUniqueWordsQty());
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/realworld/HugeRealWorldClassTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/realworld/HugeRealWorldClassTest.java
@@ -2,26 +2,26 @@ package com.github.mauricioaniche.ck.realworld;
 
 import com.github.mauricioaniche.ck.BaseTest;
 import com.github.mauricioaniche.ck.CKClassResult;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 public class HugeRealWorldClassTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/real-world-huge-class");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/real-world-huge-class");
+  }
 
-	// testing whether CK crashes if the class is absurdly huge!
-	@Test
-	public void hugeClass() {
-		CKClassResult class1 = report.get("com.satoshilabs.trezor.lib.protobuf.TrezorMessage");
+  // testing whether CK crashes if the class is absurdly huge!
+  @Test
+  public void hugeClass() {
+    CKClassResult class1 = report.get("com.satoshilabs.trezor.lib.protobuf.TrezorMessage");
 
-		Assert.assertNotNull(class1);
-	}
+    Assertions.assertNotNull(class1);
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/realworld/RealWorldClassesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/realworld/RealWorldClassesTest.java
@@ -3,9 +3,9 @@ package com.github.mauricioaniche.ck.realworld;
 import com.github.mauricioaniche.ck.BaseTest;
 import com.github.mauricioaniche.ck.CKClassResult;
 import com.github.mauricioaniche.ck.CKMethodResult;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Optional;
@@ -16,202 +16,217 @@ import static org.eclipse.jdt.core.dom.Modifier.isStatic;
 
 public class RealWorldClassesTest extends BaseTest {
 
-	private static Map<String, CKClassResult> report;
+  private static Map<String, CKClassResult> report;
 
-	@BeforeClass
-	public static void setUp() {
-		report = run(fixturesDir() + "/real-world");
-	}
+  @BeforeAll
+  public static void setUp() {
+    report = run(fixturesDir() + "/real-world");
+  }
 
+  // This class was breaking, because CSVParser had anonymous types.
+  // FIX was to ignore whenever an anonymous class, subclass, or lambda expression appears.
+  @Test
+  public void commonsCsvClass() {
 
-	// This class was breaking, because CSVParser had anonymous types.
-	// FIX was to ignore whenever an anonymous class, subclass, or lambda expression appears.
-	@Test
-	public void commonsCsvClass() {
+    CKClassResult ck = report.get("debug.CSVParser");
 
-		CKClassResult ck = report.get("debug.CSVParser");
+    for (com.github.mauricioaniche.ck.CKMethodResult CKMethodResult : ck.getMethods()) {
+      System.out.println(CKMethodResult.getMethodName());
 
-		for (com.github.mauricioaniche.ck.CKMethodResult CKMethodResult : ck.getMethods()) {
-			System.out.println(CKMethodResult.getMethodName());
+      for (Map.Entry<String, Integer> entry : CKMethodResult.getVariablesUsage().entrySet()) {
+        System.out.println("- variable: " + entry.getKey());
+      }
+    }
+    System.out.println(ck);
+  }
 
-			for (Map.Entry<String, Integer> entry : CKMethodResult.getVariablesUsage().entrySet()) {
-				System.out.println("- variable: " + entry.getKey());
-			}
-		}
-		System.out.println(ck);
-	}
+  // This class contains a method with a huge javadoc, and then the LOC was getting too big for
+  // a very small method. We use a better way to count LOC now, ignoring java comments.
+  @Test
+  public void commonsCsvClass2() {
+    CKClassResult ck = report.get("org.apache.commons.csv.CSVFormat");
 
-	// This class contains a method with a huge javadoc, and then the LOC was getting too big for
-	// a very small method. We use a better way to count LOC now, ignoring java comments.
-	@Test
-	public void commonsCsvClass2() {
-		CKClassResult ck = report.get("org.apache.commons.csv.CSVFormat");
+    Assertions.assertEquals(3, ck.getMethod("isLineBreak/1[char]").get().getLoc());
+    Assertions.assertEquals(635, ck.getMethod("isLineBreak/1[char]").get().getStartLine());
 
-		Assert.assertEquals(3, ck.getMethod("isLineBreak/1[char]").get().getLoc());
-		Assert.assertEquals(635, ck.getMethod("isLineBreak/1[char]").get().getStartLine());
+    Assertions.assertEquals(
+        1575, ck.getMethod("withAllowMissingColumnNames/1[boolean]").get().getStartLine());
+  }
 
-		Assert.assertEquals(1575, ck.getMethod("withAllowMissingColumnNames/1[boolean]").get().getStartLine());
-	}
+  // this one always worked
+  @Test
+  public void xmlInputFactory() {
 
-	// this one always worked
-	@Test
-	public void xmlInputFactory() {
+    CKClassResult a = report.get("javax.xml.stream.XMLInputFactory");
+    Assertions.assertEquals(29, a.getNumberOfMethods());
 
-		CKClassResult a = report.get("javax.xml.stream.XMLInputFactory");
-		Assert.assertEquals(29, a.getNumberOfMethods());
+    Optional<CKMethodResult> m1 = a.getMethod("getXMLReporter/0");
+    Assertions.assertTrue(org.eclipse.jdt.core.dom.Modifier.isAbstract(m1.get().getModifiers()));
+  }
 
-		Optional<CKMethodResult> m1 = a.getMethod("getXMLReporter/0");
-		Assert.assertTrue(org.eclipse.jdt.core.dom.Modifier.isAbstract(m1.get().getModifiers()));
-	}
+  // in this one, a method defined inside an anonymous class, instantiated at
+  // a field was throwing an exception. The resolveBinding() was not really able
+  // to resolve the binding.
+  // Solution: in the endVisit(MethodDeclaration), if there is no method, skip it.
+  @Test
+  public void factoryFinder() {
 
-	// in this one, a method defined inside an anonymous class, instantiated at
-	// a field was throwing an exception. The resolveBinding() was not really able
-	// to resolve the binding.
-	// Solution: in the endVisit(MethodDeclaration), if there is no method, skip it.
-	@Test
-	public void factoryFinder() {
+    CKClassResult a = report.get("javax.xml.ws.spi.FactoryFinder");
+    Assertions.assertEquals(3, a.getNumberOfMethods());
+  }
 
-		CKClassResult a = report.get("javax.xml.ws.spi.FactoryFinder");
-		Assert.assertEquals(3, a.getNumberOfMethods());
-	}
+  // this was crashing, also related to the bug explained in the
+  // 'factoryFinder' test. Test a bit redundant.
+  @Test
+  public void xmlOutputFactory() {
+    CKClassResult a = report.get("javax.xml.stream.XMLOutputFactory");
+    Assertions.assertEquals(14, a.getNumberOfMethods());
+  }
 
-	// this was crashing, also related to the bug explained in the
-	// 'factoryFinder' test. Test a bit redundant.
-	@Test
-	public void xmlOutputFactory() {
-		CKClassResult a = report.get("javax.xml.stream.XMLOutputFactory");
-		Assert.assertEquals(14, a.getNumberOfMethods());
-	}
+  // this was crashing, also related to the bug explained in the
+  // 'factoryFinder' test. Test a bit redundant.
+  @Test
+  public void feature() {
+    CKClassResult a = report.get("com.hry.spring.grpc.stream.Feature");
+    Assertions.assertNotNull(a);
 
-	// this was crashing, also related to the bug explained in the
-	// 'factoryFinder' test. Test a bit redundant.
-	@Test
-	public void feature() {
-		CKClassResult a = report.get("com.hry.spring.grpc.stream.Feature");
-		Assert.assertNotNull(a);
+    Optional<CKMethodResult> m1 = a.getMethod("getNameBytes/0");
+    Assertions.assertNotNull(m1);
+  }
 
-		Optional<CKMethodResult> m1 = a.getMethod("getNameBytes/0");
-		Assert.assertNotNull(m1);
-	}
+  // the number of methods assertion below should be 2.
+  // Before, CK was returning 1, because a resolveBinding was failing.
+  // We need the JARs here to solve the bindings correctly.
+  // CK now tries binding first and, if it fails, it resorts
+  // to the information you can get at the class only.
+  @Test
+  public void greeterGrpc() {
+    CKClassResult a = report.get("com.hry.spring.grpc.simple.GreeterGrpc");
+    Assertions.assertNotNull(a);
+    CKClassResult b = report.get("com.hry.spring.grpc.simple.GreeterGrpc$GreeterImplBase");
+    Assertions.assertNotNull(b);
 
-	// the number of methods assertion below should be 2.
-	// Before, CK was returning 1, because a resolveBinding was failing.
-	// We need the JARs here to solve the bindings correctly.
-	// CK now tries binding first and, if it fails, it resorts
-	// to the information you can get at the class only.
-	@Test
-	public void greeterGrpc() {
-		CKClassResult a = report.get("com.hry.spring.grpc.simple.GreeterGrpc");
-		Assert.assertNotNull(a);
-		CKClassResult b = report.get("com.hry.spring.grpc.simple.GreeterGrpc$GreeterImplBase");
-		Assert.assertNotNull(b);
+    Assertions.assertEquals(2, b.getNumberOfMethods());
 
-		Assert.assertEquals(2, b.getNumberOfMethods());
+    CKClassResult c = report.get("com.hry.spring.grpc.simple.GreeterGrpc$GreeterBlockingStub");
+    Assertions.assertNotNull(c);
+  }
 
-		CKClassResult c = report.get("com.hry.spring.grpc.simple.GreeterGrpc$GreeterBlockingStub");
-		Assert.assertNotNull(c);
-	}
+  // this was crashing because of a lambda expression in a field.
+  // fix: consider the lambda as part of the class and/OR method it is embedded.
+  @Test
+  public void abstractSimpleHandler() {
+    CKClassResult a = report.get("com.firefly.net.tcp.AbstractSimpleHandler");
+    Assertions.assertNotNull(a);
+    Assertions.assertEquals(3, a.getNumberOfMethods());
+    Assertions.assertEquals(3, a.getNumberOfFields());
+  }
 
-	// this was crashing because of a lambda expression in a field.
-	// fix: consider the lambda as part of the class and/OR method it is embedded.
-	@Test
-	public void abstractSimpleHandler() {
-		CKClassResult a = report.get("com.firefly.net.tcp.AbstractSimpleHandler");
-		Assert.assertNotNull(a);
-		Assert.assertEquals(3, a.getNumberOfMethods());
-		Assert.assertEquals(3, a.getNumberOfFields());
-	}
+  // one more test case for the same case above. Redundant.
+  @Test
+  public void quotedQualityCSV() {
+    CKClassResult a = report.get("com.firefly.codec.http2.model.QuotedQualityCSV");
+    Assertions.assertNotNull(a);
+  }
 
-	// one more test case for the same case above. Redundant.
-	@Test
-	public void quotedQualityCSV() {
-		CKClassResult a = report.get("com.firefly.codec.http2.model.QuotedQualityCSV");
-		Assert.assertNotNull(a);
-	}
+  @Test
+  public void beanificationTestCase() {
+    Assertions.assertTrue(
+        report.containsKey(
+            "org.apache.commons.beanutils2.BeanificationTestCase$1TestIndependenceThread"));
 
-	@Test
-	public void beanificationTestCase() {
-		Assert.assertTrue(report.keySet().contains("org.apache.commons.beanutils2.BeanificationTestCase$1TestIndependenceThread"));
+    CKClassResult a =
+        report.get("org.apache.commons.beanutils2.BeanificationTestCase$1TestIndependenceThread");
+    Assertions.assertNotNull(a);
 
-		CKClassResult a = report.get("org.apache.commons.beanutils2.BeanificationTestCase$1TestIndependenceThread");
-		Assert.assertNotNull(a);
+    Assertions.assertEquals(3, a.getNumberOfMethods());
+    Assertions.assertEquals("innerclass", a.getType());
+  }
 
-		Assert.assertEquals(3, a.getNumberOfMethods());
-		Assert.assertEquals("innerclass", a.getType());
-	}
+  // this one contains subclasses
+  @Test
+  public void csvParser2() {
+    CKClassResult class1 = report.get("org.apache.commons.csv.CSVParser2");
+    CKClassResult class2 = report.get("org.apache.commons.csv.CSVParser2$CSVRecordIterator");
 
-	// this one contains subclasses
-	@Test
-	public void csvParser2() {
-		CKClassResult class1 = report.get("org.apache.commons.csv.CSVParser2");
-		CKClassResult class2 = report.get("org.apache.commons.csv.CSVParser2$CSVRecordIterator");
+    Assertions.assertNotNull(class1);
+    Assertions.assertNotNull(class2);
 
-		Assert.assertNotNull(class1);
-		Assert.assertNotNull(class2);
+    Assertions.assertEquals(4, class2.getMethods().size());
 
-		Assert.assertEquals(4, class2.getMethods().size());
+    Set<String> allMethodsInC2 =
+        class2.getMethods().stream().map(x -> x.getMethodName()).collect(Collectors.toSet());
+    Assertions.assertTrue(allMethodsInC2.contains("hasNext/0"));
+    Assertions.assertTrue(allMethodsInC2.contains("getNextRecord/0"));
+    Assertions.assertTrue(allMethodsInC2.contains("next/0"));
+    Assertions.assertTrue(allMethodsInC2.contains("remove/0"));
 
-		Set<String> allMethodsInC2 = class2.getMethods().stream().map(x -> x.getMethodName()).collect(Collectors.toSet());
-		Assert.assertTrue(allMethodsInC2.contains("hasNext/0"));
-		Assert.assertTrue(allMethodsInC2.contains("getNextRecord/0"));
-		Assert.assertTrue(allMethodsInC2.contains("next/0"));
-		Assert.assertTrue(allMethodsInC2.contains("remove/0"));
+    Set<String> allMethodsInC1 =
+        class1.getMethods().stream().map(x -> x.getMethodName()).collect(Collectors.toSet());
+    Assertions.assertTrue(allMethodsInC1.contains("createHeaderMap/0"));
+  }
 
-		Set<String> allMethodsInC1 = class1.getMethods().stream().map(x -> x.getMethodName()).collect(Collectors.toSet());
-		Assert.assertTrue(allMethodsInC1.contains("createHeaderMap/0"));
-	}
+  // one more long class with static subclasses
+  // just double checking it finds all the subclasses
+  @Test
+  public void executorUtils() {
+    CKClassResult class1 = report.get("org.apache.commons.lang.functor.ExecutorUtils");
+    Assertions.assertNotNull(class1);
+    Assertions.assertFalse(isStatic(class1.getModifiers()));
 
-	// one more long class with static subclasses
-	// just double checking it finds all the subclasses
-	@Test
-	public void executorUtils() {
-		CKClassResult class1 = report.get("org.apache.commons.lang.functor.ExecutorUtils");
-		Assert.assertNotNull(class1);
-		Assert.assertFalse(isStatic(class1.getModifiers()));
+    CKClassResult class2 =
+        report.get("org.apache.commons.lang.functor.ExecutorUtils$ChainedExecutor");
+    Assertions.assertNotNull(class2);
+    Assertions.assertTrue(isStatic(class2.getModifiers()));
 
-		CKClassResult class2 = report.get("org.apache.commons.lang.functor.ExecutorUtils$ChainedExecutor");
-		Assert.assertNotNull(class2);
-		Assert.assertTrue(isStatic(class2.getModifiers()));
+    CKClassResult class3 =
+        report.get("org.apache.commons.lang.functor.ExecutorUtils$SwitchExecutor");
+    Assertions.assertNotNull(class3);
+    Assertions.assertTrue(isStatic(class3.getModifiers()));
 
-		CKClassResult class3 = report.get("org.apache.commons.lang.functor.ExecutorUtils$SwitchExecutor");
-		Assert.assertNotNull(class3);
-		Assert.assertTrue(isStatic(class3.getModifiers()));
+    CKClassResult class4 = report.get("org.apache.commons.lang.functor.ExecutorUtils$ForExecutor");
+    Assertions.assertNotNull(class4);
+    Assertions.assertTrue(isStatic(class4.getModifiers()));
 
-		CKClassResult class4 = report.get("org.apache.commons.lang.functor.ExecutorUtils$ForExecutor");
-		Assert.assertNotNull(class4);
-		Assert.assertTrue(isStatic(class4.getModifiers()));
+    CKClassResult class5 =
+        report.get("org.apache.commons.lang.functor.ExecutorUtils$WhileExecutor");
+    Assertions.assertNotNull(class5);
+    Assertions.assertTrue(isStatic(class5.getModifiers()));
+  }
 
-		CKClassResult class5 = report.get("org.apache.commons.lang.functor.ExecutorUtils$WhileExecutor");
-		Assert.assertNotNull(class5);
-		Assert.assertTrue(isStatic(class5.getModifiers()));
+  // check whether the kerberosChallenge method is detected
+  // in one of the versions of the project, it identifies the method with a wrong arity.
+  // TODO: find this version.
+  @Test
+  public void asyncHttpClient_1() {
+    CKClassResult class1 =
+        report.get("org.asynchttpclient.netty.handler.intercept.Unauthorized401Interceptor");
 
-	}
+    CKMethodResult method =
+        class1
+            .getMethod(
+                "kerberosChallenge/3[org.asynchttpclient.netty.handler.intercept.Realm,org.asynchttpclient.netty.handler.intercept.Request,org.asynchttpclient.netty.handler.intercept.HttpHeaders]")
+            .get();
+    Assertions.assertNotNull(method);
+  }
 
-	// check whether the kerberosChallenge method is detected
-	// in one of the versions of the project, it identifies the method with a wrong arity.
-	// TODO: find this version.
-	@Test
-	public void asyncHttpClient_1() {
-		CKClassResult class1 = report.get("org.asynchttpclient.netty.handler.intercept.Unauthorized401Interceptor");
+  @Test
+  public void asyncHttpClient_2() {
+    CKClassResult class1 = report.get("com.ning.http.client.providers.NettyAsyncHttpProvider");
+    System.out.println(class1.getMethods());
 
-		CKMethodResult method = class1.getMethod("kerberosChallenge/3[org.asynchttpclient.netty.handler.intercept.Realm,org.asynchttpclient.netty.handler.intercept.Request,org.asynchttpclient.netty.handler.intercept.HttpHeaders]").get();
-		Assert.assertNotNull(method);
-	}
+    Assertions.assertNotNull(
+        class1.getMethod(
+            "doConnect/3[com.ning.http.client.providers.Request,com.ning.http.client.providers.AsyncHandler<T>,com.ning.http.client.providers.NettyResponseFuture<T>]"));
+  }
 
-	@Test
-	public void asyncHttpClient_2() {
-		CKClassResult class1 = report.get("com.ning.http.client.providers.NettyAsyncHttpProvider");
-		System.out.println(class1.getMethods());
-
-		Assert.assertNotNull(class1.getMethod("doConnect/3[com.ning.http.client.providers.Request,com.ning.http.client.providers.AsyncHandler<T>,com.ning.http.client.providers.NettyResponseFuture<T>]"));
-	}
-
-	// illustrates the example of https://github.com/mauricioaniche/ck/issues/54
-	// still to be implemented
-	@Test
-	public void hectorPolicyManager_betterNamesForAnonymousClasses() {
-		CKClassResult class1 = report.get("net.retakethe.policyauction.data.impl.HectorPolicyManagerImpl");
-		CKClassResult anonymousClass = report.get("net.retakethe.policyauction.data.impl.HectorPolicyManagerImpl$Anonymous1");
-	}
-
+  // illustrates the example of https://github.com/mauricioaniche/ck/issues/54
+  // still to be implemented
+  @Test
+  public void hectorPolicyManager_betterNamesForAnonymousClasses() {
+    CKClassResult class1 =
+        report.get("net.retakethe.policyauction.data.impl.HectorPolicyManagerImpl");
+    CKClassResult anonymousClass =
+        report.get("net.retakethe.policyauction.data.impl.HectorPolicyManagerImpl$Anonymous1");
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/util/LOCCalculatorTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/util/LOCCalculatorTest.java
@@ -1,183 +1,170 @@
 package com.github.mauricioaniche.ck.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LOCCalculatorTest {
 
+  @Test
+  public void noComments() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\r\n");
+    sb.append("\tprivate int 1;\r\n");
+    sb.append("\tvoid m1() {\r\n");
+    sb.append("\t\tSystem.out.println(\"aa\");\r\n");
+    sb.append("}\r\n");
 
-	@Test
-	public void noComments() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\r\n");
-		sb.append("\tprivate int 1;\r\n");
-		sb.append("\tvoid m1() {\r\n");
-		sb.append("\t\tSystem.out.println(\"aa\");\r\n");
-		sb.append("}\r\n");
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(5, loc);
+  }
 
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
-	}
+  @Test
+  public void noSlashR() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\n");
+    sb.append("private int 1;\n");
+    sb.append("void m1() {\n");
+    sb.append("System.out.println(\"aa\");\n");
+    sb.append("}\n");
 
-	@Test
-	public void noSlashR() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\n");
-		sb.append("private int 1;\n");
-		sb.append("void m1() {\n");
-		sb.append("System.out.println(\"aa\");\n");
-		sb.append("}\n");
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(5, loc);
+  }
 
+  @Test
+  public void singleLineComment() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\n");
+    sb.append("\t// comment\n");
+    sb.append("\t//comment\n");
+    sb.append("private int 1;\n");
+    sb.append("void m1() {\n");
+    sb.append("System.out.println(\"aa\");\n");
+    sb.append("}\n");
 
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
-	}
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(5, loc);
+  }
 
-	@Test
-	public void singleLineComment() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\n");
-		sb.append("\t// comment\n");
-		sb.append("\t//comment\n");
-		sb.append("private int 1;\n");
-		sb.append("void m1() {\n");
-		sb.append("System.out.println(\"aa\");\n");
-		sb.append("}\n");
+  @Test
+  public void singleLineCommentWithStar() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\n");
+    sb.append("\t/* comment */\n");
+    sb.append("\t/*comment*/\n");
+    sb.append("private int 1;\n");
+    sb.append("void m1() {\n");
+    sb.append("System.out.println(\"aa\");\n");
+    sb.append("}\n");
 
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(5, loc);
+  }
 
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
-	}
+  @Test
+  public void multiLineComment() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\n");
+    sb.append("\t/* comment\n");
+    sb.append("\t * comment\n");
+    sb.append("\t */\n");
+    sb.append("\t/** comment\n");
+    sb.append("\t * comment\n");
+    sb.append("\t */\n");
+    sb.append("private int 1;\n");
+    sb.append("void m1() {\n");
+    sb.append("System.out.println(\"aa\");\n");
+    sb.append("}\n");
 
-	@Test
-	public void singleLineCommentWithStar() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\n");
-		sb.append("\t/* comment */\n");
-		sb.append("\t/*comment*/\n");
-		sb.append("private int 1;\n");
-		sb.append("void m1() {\n");
-		sb.append("System.out.println(\"aa\");\n");
-		sb.append("}\n");
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(5, loc);
+  }
 
+  @Test
+  public void codeAndComment() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\n");
+    sb.append("private int 1;\n");
+    sb.append("void m1() { // comment \n");
+    sb.append("System.out.println(\"aa\");//comment\n");
+    sb.append("}\n");
 
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
-	}
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(5, loc);
+  }
 
-	@Test
-	public void multiLineComment() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\n");
-		sb.append("\t/* comment\n");
-		sb.append("\t * comment\n");
-		sb.append("\t */\n");
-		sb.append("\t/** comment\n");
-		sb.append("\t * comment\n");
-		sb.append("\t */\n");
-		sb.append("private int 1;\n");
-		sb.append("void m1() {\n");
-		sb.append("System.out.println(\"aa\");\n");
-		sb.append("}\n");
+  @Test
+  public void codeAndCommentAndCode() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\n");
+    sb.append("private int 1;\n");
+    sb.append("void m1() { /* comment */ int a; \n");
+    sb.append("System.out.println(\"aa\");//comment\n");
+    sb.append("}\n");
 
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(5, loc);
+  }
 
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
-	}
+  @Test
+  public void commentEndOfFile() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\n");
+    sb.append("private int 1;\n");
+    sb.append("void m1() { // comment \n");
+    sb.append("System.out.println(\"aa\");//comment\n");
+    sb.append("}// comment\n");
+    sb.append("// comment");
 
-	@Test
-	public void codeAndComment() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\n");
-		sb.append("private int 1;\n");
-		sb.append("void m1() { // comment \n");
-		sb.append("System.out.println(\"aa\");//comment\n");
-		sb.append("}\n");
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(5, loc);
+  }
 
+  @Test
+  public void lambda() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\n");
+    sb.append("private int 1;\n");
+    sb.append("void m1() { // comment \n");
+    sb.append("() -> { }; //comment\n");
+    sb.append("() -> { /* aa */ };\n");
+    sb.append("}// comment\n");
+    sb.append("// comment");
 
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
-	}
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(6, loc);
+  }
 
-	@Test
-	public void codeAndCommentAndCode() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\n");
-		sb.append("private int 1;\n");
-		sb.append("void m1() { /* comment */ int a; \n");
-		sb.append("System.out.println(\"aa\");//comment\n");
-		sb.append("}\n");
+  @Test
+  public void noEndOfLine() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\r\n");
+    sb.append("\tprivate int 1;\r\n");
+    sb.append("\tvoid m1() {\r\n");
+    sb.append("\t\tSystem.out.println(\"aa\");\r\n");
+    sb.append("}");
 
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(5, loc);
+  }
 
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
-	}
+  @Test
+  public void emptyLines() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class A {\r\n");
+    sb.append("\r\n");
+    sb.append("\tprivate int 1;\r\n");
+    sb.append("\r\n");
+    sb.append("\tvoid m1() {\r\n");
+    sb.append("\t\tSystem.out.println(\"aa\");\r\n");
+    sb.append("\r\n");
+    sb.append("\r\n");
+    sb.append("\r\n");
+    sb.append("\r\n");
+    sb.append("}");
+    sb.append("\r\n");
 
-	@Test
-	public void commentEndOfFile() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\n");
-		sb.append("private int 1;\n");
-		sb.append("void m1() { // comment \n");
-		sb.append("System.out.println(\"aa\");//comment\n");
-		sb.append("}// comment\n");
-		sb.append("// comment");
-
-
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
-	}
-
-	@Test
-	public void lambda() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\n");
-		sb.append("private int 1;\n");
-		sb.append("void m1() { // comment \n");
-		sb.append("() -> { }; //comment\n");
-		sb.append("() -> { /* aa */ };\n");
-		sb.append("}// comment\n");
-		sb.append("// comment");
-
-
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(6, loc);
-	}
-
-	@Test
-	public void noEndOfLine() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\r\n");
-		sb.append("\tprivate int 1;\r\n");
-		sb.append("\tvoid m1() {\r\n");
-		sb.append("\t\tSystem.out.println(\"aa\");\r\n");
-		sb.append("}");
-
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
-	}
-
-
-	@Test
-	public void emptyLines() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("class A {\r\n");
-		sb.append("\r\n");
-		sb.append("\tprivate int 1;\r\n");
-		sb.append("\r\n");
-		sb.append("\tvoid m1() {\r\n");
-		sb.append("\t\tSystem.out.println(\"aa\");\r\n");
-		sb.append("\r\n");
-		sb.append("\r\n");
-		sb.append("\r\n");
-		sb.append("\r\n");
-		sb.append("}");
-		sb.append("\r\n");
-
-		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
-	}
-
-
-
+    int loc = LOCCalculator.calculate(sb.toString());
+    Assertions.assertEquals(5, loc);
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/util/WordCounterTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/util/WordCounterTest.java
@@ -1,60 +1,62 @@
 package com.github.mauricioaniche.ck.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
 public class WordCounterTest {
 
-	@Test
-	public void countWords() {
-		String sourceCode = "a b c d r$ a@ h^";
+  @Test
+  public void countWords() {
+    String sourceCode = "a b c d r$ a@ h^";
 
-		Set<String> words = WordCounter.wordsIn(sourceCode);
-		Assert.assertEquals(4, words.size());
-		Assert.assertTrue(words.contains("a"));
-		Assert.assertTrue(words.contains("b"));
-		Assert.assertTrue(words.contains("c"));
-		Assert.assertTrue(words.contains("d"));
-	}
+    Set<String> words = WordCounter.wordsIn(sourceCode);
+    Assertions.assertEquals(4, words.size());
+    Assertions.assertTrue(words.contains("a"));
+    Assertions.assertTrue(words.contains("b"));
+    Assertions.assertTrue(words.contains("c"));
+    Assertions.assertTrue(words.contains("d"));
+  }
 
-	@Test
-	public void ignoreJavaKeywords() {
-		String sourceCode = "package a.b.c;\n" +
-				"class Test {\n" +
-				"@Tests public void metodo() {\n" +
-				"  int taxes = 10;\n" +
-				"  double interests = 0;"+
-				"\n} }";
+  @Test
+  public void ignoreJavaKeywords() {
+    String sourceCode =
+        "package a.b.c;\n"
+            + "class Test {\n"
+            + "@Tests public void metodo() {\n"
+            + "  int taxes = 10;\n"
+            + "  double interests = 0;"
+            + "\n} }";
 
-		Set<String> words = WordCounter.wordsIn(sourceCode);
-		Assert.assertEquals(4, words.size());
-		Assert.assertTrue(words.contains("Test"));
-		Assert.assertTrue(words.contains("metodo"));
-		Assert.assertTrue(words.contains("taxes"));
-		Assert.assertTrue(words.contains("interests"));
+    Set<String> words = WordCounter.wordsIn(sourceCode);
+    Assertions.assertEquals(4, words.size());
+    Assertions.assertTrue(words.contains("Test"));
+    Assertions.assertTrue(words.contains("metodo"));
+    Assertions.assertTrue(words.contains("taxes"));
+    Assertions.assertTrue(words.contains("interests"));
+  }
 
-	}
+  @Test
+  public void breakWords() {
+    String sourceCode = "thisIsABigWord another_word_like_this now_weMix";
+    Set<String> words = WordCounter.wordsIn(sourceCode);
 
-	@Test
-	public void breakWords() {
-		String sourceCode = "thisIsABigWord another_word_like_this now_weMix";
-		Set<String> words = WordCounter.wordsIn(sourceCode);
+    Assertions.assertEquals(11, words.size());
 
-		Assert.assertEquals(11, words.size());
+    String[] expected =
+        new String[] {
+          "A", "Big", "Word", "like", "another", "now", "this", "Is", "word", "Mix", "we"
+        };
+    for (String expectedString : expected) {
+      Assertions.assertTrue(words.contains(expectedString));
+    }
+  }
 
-		String[] expected = new String[] { "A", "Big", "Word", "like", "another", "now", "this", "Is", "word", "Mix", "we"};
-		for (String expectedString : expected) {
-			Assert.assertTrue(words.contains(expectedString));
-		}
-	}
+  @Test
+  public void mixOfCamelCase_and_underscore() {
+    Set<String> words = WordCounter.wordsIn("longName_likeThis");
 
-	@Test
-	public void mixOfCamelCase_and_underscore() {
-		Set<String> words = WordCounter.wordsIn("longName_likeThis");
-
-		Assert.assertEquals(4, words.size());
-	}
-
+    Assertions.assertEquals(4, words.size());
+  }
 }


### PR DESCRIPTION
- Now the method reference calls are counted in the RFC metrics

- I updated the pom to use Junit 5

This new version has a readable api and some useful things, such as @DisplayName, to declare more friendly names for test cases.

All old tests are ok with the new version of Junit, I had to change the package of some annotations, but everything works.