### PR TITLE
Update JUnit to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,11 @@
 				</executions>
 			</plugin>
 
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12-beta-3</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.4</version>
@@ -99,6 +92,13 @@
 			<groupId>org.pitest</groupId>
 			<artifactId>pitest-maven</artifactId>
 			<version>1.4.11</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.5.2</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/test/java/com/github/mauricioaniche/ck/BindingsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/BindingsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class BindingsTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/bindings");
 	}
@@ -19,13 +19,13 @@ public class BindingsTest extends BaseTest {
 	@Test
 	public void fullNameEvenWhenTypesAreNotAvailable() {
 		CKClassResult a = report.get("bind.BindingFail1");
-		Assert.assertNotNull(a);
+		Assertions.assertNotNull(a);
 	}
 
 	@Test
 	public void fullNameEvenWhenTypesAreNotAvailableNotEvenInImports() {
 		CKClassResult a = report.get("bind.BindingFail2");
-		Assert.assertNotNull(a);
+		Assertions.assertNotNull(a);
 	}
 
 }

--- a/src/test/java/com/github/mauricioaniche/ck/CBOTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/CBOTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class CBOTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/cbo");
 	}
@@ -18,78 +18,78 @@ public class CBOTest extends BaseTest {
 	@Test
 	public void ignoreJavaTypes() {
 		CKClassResult a = report.get("cbo.Coupling0");
-		Assert.assertEquals(0, a.getCbo());
+		Assertions.assertEquals(0, a.getCbo());
 	}
 	
 	@Test
 	public void countDifferentPossibilitiesOfDependencies() {
 		
 		CKClassResult a = report.get("cbo.Coupling1");
-		Assert.assertEquals(6, a.getCbo());
+		Assertions.assertEquals(6, a.getCbo());
 	}
 	
 	@Test
 	public void countEvenWhenNotResolved() {
 		
 		CKClassResult a = report.get("cbo.Coupling3");
-		Assert.assertEquals(1, a.getCbo());
+		Assertions.assertEquals(1, a.getCbo());
 	}
 	
 	@Test
 	public void countInterfacesAndInheritances() {
 		
 		CKClassResult b = report.get("cbo.Coupling2");
-		Assert.assertEquals(5, b.getCbo());
+		Assertions.assertEquals(5, b.getCbo());
 	}
 
 	@Test
 	public void countClassCreations() {
 		CKClassResult b = report.get("cbo.Coupling4");
-		Assert.assertEquals(3, b.getCbo());
+		Assertions.assertEquals(3, b.getCbo());
 	}
 
 	@Test
 	public void countMethodParameters() {
 		
 		CKClassResult b = report.get("cbo.MethodParams");
-		Assert.assertEquals(2, b.getCbo());
+		Assertions.assertEquals(2, b.getCbo());
 	}
 
 	@Test
 	public void methodLevel() {
 		CKClassResult b = report.get("cbo.Coupling5");
-		Assert.assertEquals(0, b.getMethod("am1/0").get().getCbo());
-		Assert.assertEquals(1, b.getMethod("am2/0").get().getCbo());
-		Assert.assertEquals(1, b.getMethod("am3/0").get().getCbo());
-		Assert.assertEquals(2, b.getMethod("am4/0").get().getCbo());
+		Assertions.assertEquals(0, b.getMethod("am1/0").get().getCbo());
+		Assertions.assertEquals(1, b.getMethod("am2/0").get().getCbo());
+		Assertions.assertEquals(1, b.getMethod("am3/0").get().getCbo());
+		Assertions.assertEquals(2, b.getMethod("am4/0").get().getCbo());
 	}
 
 	@Test
 	public void fullOfNonResolvedTypes() {
 		CKClassResult b = report.get("cbo.NotResolved");
-		Assert.assertEquals(5, b.getCbo());
+		Assertions.assertEquals(5, b.getCbo());
 	}
 
 	// based on issue #43
 	@Test
 	public void couplingWithGenericsAndJavaType() {
 		CKClassResult b = report.get("cbo.Coupling6");
-		Assert.assertEquals(1, b.getCbo());
+		Assertions.assertEquals(1, b.getCbo());
 
 		CKClassResult c = report.get("cbo.Coupling61");
-		Assert.assertEquals(1, c.getCbo());
+		Assertions.assertEquals(1, c.getCbo());
 
 		CKClassResult d = report.get("cbo.Coupling62");
-		Assert.assertEquals(2, d.getCbo());
+		Assertions.assertEquals(2, d.getCbo());
 
 		CKClassResult e = report.get("cbo.Coupling63");
-		Assert.assertEquals(2, e.getCbo());
+		Assertions.assertEquals(2, e.getCbo());
 
 		CKClassResult f = report.get("cbo.Coupling64");
-		Assert.assertEquals(2, f.getCbo());
+		Assertions.assertEquals(2, f.getCbo());
 
 		CKClassResult g = report.get("cbo.Coupling65");
-		Assert.assertEquals(2, g.getCbo());
+		Assertions.assertEquals(2, g.getCbo());
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/ClassTypeTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/ClassTypeTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -12,7 +12,7 @@ public class ClassTypeTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/class-types");
 	}
@@ -21,22 +21,22 @@ public class ClassTypeTest extends BaseTest {
 	@Test
 	public void identifyTypesCorrectly() {
 
-		Assert.assertEquals(5, report.size());
+		Assertions.assertEquals(5, report.size());
 
 		CKClassResult a = report.get("classtypes.A");
-		Assert.assertEquals("class", a.getType());
+		Assertions.assertEquals("class", a.getType());
 
 		CKClassResult b = report.get("classtypes.A$B");
-		Assert.assertEquals("innerclass", b.getType());
+		Assertions.assertEquals("innerclass", b.getType());
 
 		CKClassResult mathOperation = report.get("classtypes.MathOperation");
-		Assert.assertEquals("interface", mathOperation.getType());
+		Assertions.assertEquals("interface", mathOperation.getType());
 
 		CKClassResult anon1 = report.get("classtypes.A$Anonymous1");
-		Assert.assertEquals("anonymous", anon1.getType());
+		Assertions.assertEquals("anonymous", anon1.getType());
 
 		CKClassResult anon2 = report.get("classtypes.A$Anonymous2");
-		Assert.assertEquals("anonymous", anon2.getType());
+		Assertions.assertEquals("anonymous", anon2.getType());
 
 
 	}

--- a/src/test/java/com/github/mauricioaniche/ck/DITTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/DITTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -11,7 +11,7 @@ public class DITTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/dit");
 	}
@@ -19,34 +19,34 @@ public class DITTest extends BaseTest {
 	@Test
 	public void everyOneHasObjectAsFather() {
 		CKClassResult a = report.get("dit.A");
-		Assert.assertEquals(1, a.getDit());
+		Assertions.assertEquals(1, a.getDit());
 	}
 
 	@Test
 	public void firstLevelInheritance() {
 		CKClassResult b = report.get("dit.B");
-		Assert.assertEquals(2, b.getDit());
+		Assertions.assertEquals(2, b.getDit());
 	}
 	
 	@Test
 	public void twoLevelsInheritance() {
 		CKClassResult c = report.get("dit.C");
-		Assert.assertEquals(3, c.getDit());
+		Assertions.assertEquals(3, c.getDit());
 
 		CKClassResult c2 = report.get("dit.C2");
-		Assert.assertEquals(3, c2.getDit());
+		Assertions.assertEquals(3, c2.getDit());
 	}
 	
 	@Test
 	public void threeLevelsInheritance() {
 		CKClassResult d = report.get("dit.D");
-		Assert.assertEquals(4, d.getDit());
+		Assertions.assertEquals(4, d.getDit());
 	}
 	
 	@Test
 	public void countEvenClassesNotResolved() {
 		CKClassResult a = report.get("dit.X");
-		Assert.assertEquals(2, a.getDit());
+		Assertions.assertEquals(2, a.getDit());
 	}
 
 }

--- a/src/test/java/com/github/mauricioaniche/ck/EnumTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/EnumTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class EnumTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/enumdecl");
 	}
@@ -19,33 +19,33 @@ public class EnumTest extends BaseTest {
 	public void testEnum() {
 		CKClassResult a = report.get("enumd.EnumDecl");
 
-		Assert.assertEquals(2, a.getMethods().size());
+		Assertions.assertEquals(2, a.getMethods().size());
 
 		CKMethodResult m1 = a.getMethods().stream().filter(x -> x.getMethodName().contains("getX")).findFirst().get();
-		Assert.assertEquals("getX/0", m1.getMethodName());
-		Assert.assertEquals(1, m1.getReturnQty());
-		Assert.assertEquals(1, m1.getLoopQty());
+		Assertions.assertEquals("getX/0", m1.getMethodName());
+		Assertions.assertEquals(1, m1.getReturnQty());
+		Assertions.assertEquals(1, m1.getLoopQty());
 
 	}
 
 	@Test
 	public void maxNestedDepth() {
 		CKClassResult b = report.get("enumd.EnumDecl2");
-		Assert.assertEquals(1, b.getMethod("url/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(4, b.getMethod("m2/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(1, b.getMethod("url/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(4, b.getMethod("m2/0").get().getMaxNestedBlocks());
 	}
 
 	@Test
 	public void subclasses() {
 		CKClassResult b = report.get("enumd.EnumDecl3");
 
-		Assert.assertEquals(1, b.getMethod("getX/0").get().getInnerClassesQty());
-		Assert.assertEquals(2, b.getInnerClassesQty());
+		Assertions.assertEquals(1, b.getMethod("getX/0").get().getInnerClassesQty());
+		Assertions.assertEquals(2, b.getInnerClassesQty());
 
 		CKClassResult sc = report.get("enumd.EnumDecl3$1Other");
-		Assert.assertEquals(4, sc.getNumberOfMethods());
-		Assert.assertEquals(3, sc.getMethod("x1/0").get().getWmc());
-		Assert.assertEquals(2, sc.getMethod("x1/0").get().getVariablesQty());
+		Assertions.assertEquals(4, sc.getNumberOfMethods());
+		Assertions.assertEquals(3, sc.getMethod("x1/0").get().getWmc());
+		Assertions.assertEquals(2, sc.getMethod("x1/0").get().getVariablesQty());
 
 	}
 

--- a/src/test/java/com/github/mauricioaniche/ck/FieldUsageTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/FieldUsageTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class FieldUsageTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/fieldusage");
 	}
@@ -21,16 +21,16 @@ public class FieldUsageTest extends BaseTest {
 
 		CKMethodResult m1 = a.getMethod("m1/0").get();
 		Map<String, Integer> m1Fields = m1.getFieldUsage();
-		Assert.assertEquals(2, m1Fields.get("a").intValue());
-		Assert.assertEquals(1, m1Fields.get("b").intValue());
+		Assertions.assertEquals(2, m1Fields.get("a").intValue());
+		Assertions.assertEquals(1, m1Fields.get("b").intValue());
 
 		CKMethodResult m3 = a.getMethod("m3/0").get();
 		Map<String, Integer> m3Fields = m3.getFieldUsage();
-		Assert.assertEquals(2, m3Fields.get("a").intValue());
+		Assertions.assertEquals(2, m3Fields.get("a").intValue());
 
 		CKMethodResult m2 = a.getMethod("m2/0").get();
 		Map<String, Integer> m2Fields = m2.getFieldUsage();
-		Assert.assertEquals(1, m2Fields.get("a").intValue());
+		Assertions.assertEquals(1, m2Fields.get("a").intValue());
 	}
 
 	@Test
@@ -39,6 +39,6 @@ public class FieldUsageTest extends BaseTest {
 
 		CKMethodResult m4 = a.getMethod("m4/0").get();
 		Map<String, Integer> m2Fields = m4.getFieldUsage();
-		Assert.assertEquals(2, m2Fields.get("xx").intValue());
+		Assertions.assertEquals(2, m2Fields.get("xx").intValue());
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/FieldsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/FieldsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -11,7 +11,7 @@ public class FieldsTest extends BaseTest {
 
     private static Map<String, CKClassResult> report;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         report = run(fixturesDir() + "/fields");
     }
@@ -19,51 +19,51 @@ public class FieldsTest extends BaseTest {
     @Test
     public void all() {
         CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(10, a.getNumberOfFields());
+        Assertions.assertEquals(10, a.getNumberOfFields());
     }
 
     @Test
     public void allPublic() {
         CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(3, a.getNumberOfPublicFields());
+        Assertions.assertEquals(3, a.getNumberOfPublicFields());
     }
 
     @Test
     public void allStatic() {
         CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(3, a.getNumberOfStaticFields());
+        Assertions.assertEquals(3, a.getNumberOfStaticFields());
     }
 
 
     @Test
     public void allPrivate() {
         CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(4, a.getNumberOfPrivateFields());
+        Assertions.assertEquals(4, a.getNumberOfPrivateFields());
     }
 
 
     @Test
     public void allDefault() {
         CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(2, a.getNumberOfDefaultFields());
+        Assertions.assertEquals(2, a.getNumberOfDefaultFields());
     }
 
     @Test
     public void allSynchronized() {
         CKClassResult a = report.get("fields.Fields");
-        Assert.assertEquals(1, a.getNumberOfSynchronizedFields());
+        Assertions.assertEquals(1, a.getNumberOfSynchronizedFields());
     }
 
     @Test
     public void allProtected() {
         CKClassResult a = report.get(("fields.Fields"));
-        Assert.assertEquals(1, a.getNumberOfProtectedFields());
+        Assertions.assertEquals(1, a.getNumberOfProtectedFields());
     }
 
     @Test
     public void AllFinal() {
         CKClassResult a = report.get(("fields.Fields"));
-        Assert.assertEquals(1, a.getNumberOfFinalFields());
+        Assertions.assertEquals(1, a.getNumberOfFinalFields());
 
     }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/GenericsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/GenericsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class GenericsTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/generics");
 	}
@@ -18,13 +18,13 @@ public class GenericsTest extends BaseTest {
 	@Test
 	public void genericMethods() {
 		CKClassResult r = report.get("bg.Generics");
-		Assert.assertEquals(2, r.getMethods().size());
+		Assertions.assertEquals(2, r.getMethods().size());
 
 		// method names are the same, but starting line is different
-		Assert.assertEquals(1, r.getMethods().stream()
+		Assertions.assertEquals(1, r.getMethods().stream()
 				.filter(x -> x.getMethodName().equals("notEmpty/3[T,java.lang.String,java.lang.Object[]]") && x.getStartLine() == 9).count());
 
-		Assert.assertEquals(1, r.getMethods().stream()
+		Assertions.assertEquals(1, r.getMethods().stream()
 				.filter(x -> x.getMethodName().equals("notEmpty/3[T,java.lang.String,java.lang.Object[]]") && x.getStartLine() == 13).count());
 
 	}
@@ -33,7 +33,7 @@ public class GenericsTest extends BaseTest {
 	public void noGenericsInClassName() {
 		CKClassResult r = report.get("bg.Generics2");
 
-		Assert.assertNotNull(r);
+		Assertions.assertNotNull(r);
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/JDTUtilsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/JDTUtilsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class JDTUtilsTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/jdt");
 	}
@@ -19,9 +19,9 @@ public class JDTUtilsTest extends BaseTest {
 	public void methodNames() {
 		CKClassResult a = report.get("jdt.Jdt1");
 
-		Assert.assertTrue(a.getMethod("m1/0").isPresent());
-		Assert.assertTrue(a.getMethod("m2/2[int,double]").isPresent());
-		Assert.assertTrue(a.getMethod("m3/3[int,jdt.A,double]").isPresent());
-		Assert.assertTrue(a.getMethod("m4/4[int,int[],java.lang.String[],jdt.A[]]").isPresent());
+		Assertions.assertTrue(a.getMethod("m1/0").isPresent());
+		Assertions.assertTrue(a.getMethod("m2/2[int,double]").isPresent());
+		Assertions.assertTrue(a.getMethod("m3/3[int,jdt.A,double]").isPresent());
+		Assertions.assertTrue(a.getMethod("m4/4[int,int[],java.lang.String[],jdt.A[]]").isPresent());
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/Java11SupportTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/Java11SupportTest.java
@@ -1,19 +1,19 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Java11SupportTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/java11");
 	}

--- a/src/test/java/com/github/mauricioaniche/ck/LCOMTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/LCOMTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class LCOMTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/lcom");
 	}
@@ -19,16 +19,16 @@ public class LCOMTest extends BaseTest {
 	public void should_count_lcom() {
 		
 		CKClassResult a = report.get("lcom.TripStatusBean");
-		Assert.assertEquals(1415, a.getLcom());
+		Assertions.assertEquals(1415, a.getLcom());
 
 		CKClassResult b = report.get("lcom.SimpleGetterAndSetter");
-		Assert.assertEquals(0, b.getLcom());
+		Assertions.assertEquals(0, b.getLcom());
 
 		CKClassResult c = report.get("lcom.SimpleGetterAndSetter2");
-		Assert.assertEquals(2, c.getLcom());
+		Assertions.assertEquals(2, c.getLcom());
 
 		CKClassResult d = report.get("lcom.TermsOfServiceController");
-		Assert.assertEquals(0, d.getLcom());
+		Assertions.assertEquals(0, d.getLcom());
 
 	}
 	

--- a/src/test/java/com/github/mauricioaniche/ck/LOCTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/LOCTest.java
@@ -1,7 +1,7 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -14,7 +14,7 @@ public class LOCTest extends BaseTest {
 		CKClassResult a = report.get("cbo.Coupling1");
 
 		// note that the package line should not count here
-		Assert.assertEquals(10, a.getLoc());
+		Assertions.assertEquals(10, a.getLoc());
 	}
 
 	@Test
@@ -22,16 +22,16 @@ public class LOCTest extends BaseTest {
 		Map<String, CKClassResult> report = run(fixturesDir() + "/innerclasses");
 
 		CKClassResult a = report.get("innerclasses.MessyClass");
-		Assert.assertEquals(65, a.getLoc());
+		Assertions.assertEquals(65, a.getLoc());
 
 		CKClassResult sc1 = report.get("innerclasses.MessyClass$InnerClass1");
-		Assert.assertEquals(14, sc1.getLoc());
+		Assertions.assertEquals(14, sc1.getLoc());
 
 		CKClassResult sc2 = report.get("innerclasses.MessyClass$InnerClass2");
-		Assert.assertEquals(9, sc2.getLoc());
+		Assertions.assertEquals(9, sc2.getLoc());
 
 		CKClassResult an1 = report.get("innerclasses.MessyClass$Anonymous1");
-		Assert.assertEquals(5, an1.getLoc());
+		Assertions.assertEquals(5, an1.getLoc());
 	}
 	
 }

--- a/src/test/java/com/github/mauricioaniche/ck/MethodsDetailsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/MethodsDetailsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class MethodsDetailsTest extends BaseTest{
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/details-methods");
 	}
@@ -18,40 +18,40 @@ public class MethodsDetailsTest extends BaseTest{
 	@Test
 	public void loc() {
 		CKClassResult a = report.get("methods2.A1");
-		Assert.assertEquals(6, a.getMethod("a/0").get().getLoc());
-		Assert.assertEquals(2, a.getMethod("b/0").get().getLoc());
+		Assertions.assertEquals(6, a.getMethod("a/0").get().getLoc());
+		Assertions.assertEquals(2, a.getMethod("b/0").get().getLoc());
 	}
 
 	@Test
 	public void parameterQty() {
 		CKClassResult a = report.get("methods2.A1");
-		Assert.assertEquals(3, a.getMethod("c/3[int,int,methods2.A]").get().getParametersQty());
-		Assert.assertEquals(0, a.getMethod("a/0").get().getParametersQty());
+		Assertions.assertEquals(3, a.getMethod("c/3[int,int,methods2.A]").get().getParametersQty());
+		Assertions.assertEquals(0, a.getMethod("a/0").get().getParametersQty());
 	}
 
 	@Test
 	public void variableQty() {
 		CKClassResult a = report.get("methods2.A1");
-		Assert.assertEquals(5, a.getMethod("a/0").get().getVariablesQty());
-		Assert.assertEquals(1, a.getMethod("c/3[int,int,methods2.A]").get().getVariablesQty());
-		Assert.assertEquals(0, a.getMethod("b/0").get().getVariablesQty());
+		Assertions.assertEquals(5, a.getMethod("a/0").get().getVariablesQty());
+		Assertions.assertEquals(1, a.getMethod("c/3[int,int,methods2.A]").get().getVariablesQty());
+		Assertions.assertEquals(0, a.getMethod("b/0").get().getVariablesQty());
 	}
 
 	@Test
 	public void returnQty() {
 		CKClassResult a = report.get("methods2.A1");
-		Assert.assertEquals(0, a.getMethod("c/3[int,int,methods2.A]").get().getReturnQty());
-		Assert.assertEquals(0, a.getMethod("a/0").get().getReturnQty());
-		Assert.assertEquals(3, a.getMethod("d/0").get().getReturnQty());
-		Assert.assertEquals(1, a.getMethod("e/0").get().getReturnQty());
+		Assertions.assertEquals(0, a.getMethod("c/3[int,int,methods2.A]").get().getReturnQty());
+		Assertions.assertEquals(0, a.getMethod("a/0").get().getReturnQty());
+		Assertions.assertEquals(3, a.getMethod("d/0").get().getReturnQty());
+		Assertions.assertEquals(1, a.getMethod("e/0").get().getReturnQty());
 	}
 
 	@Test
 	public void lineNumber() {
 		CKClassResult a = report.get("methods2.A1");
-		Assert.assertEquals(18, a.getMethod("c/3[int,int,methods2.A]").get().getStartLine());
-		Assert.assertEquals(5, a.getMethod("a/0").get().getStartLine());
-		Assert.assertEquals(22, a.getMethod("d/0").get().getStartLine());
-		Assert.assertEquals(29, a.getMethod("e/0").get().getStartLine());
+		Assertions.assertEquals(18, a.getMethod("c/3[int,int,methods2.A]").get().getStartLine());
+		Assertions.assertEquals(5, a.getMethod("a/0").get().getStartLine());
+		Assertions.assertEquals(22, a.getMethod("d/0").get().getStartLine());
+		Assertions.assertEquals(29, a.getMethod("e/0").get().getStartLine());
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/MethodsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/MethodsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Optional;
@@ -11,7 +11,7 @@ public class MethodsTest extends BaseTest {
 
     private static Map<String, CKClassResult> report;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         report = run(fixturesDir() + "/methods");
     }
@@ -19,67 +19,67 @@ public class MethodsTest extends BaseTest {
     @Test
     public void all() {
         CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(9, a.getNumberOfMethods());
+        Assertions.assertEquals(9, a.getNumberOfMethods());
     }
 
     @Test
     public void allPublic() {
         CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(4, a.getNumberOfPublicMethods());
+        Assertions.assertEquals(4, a.getNumberOfPublicMethods());
     }
 
     @Test
     public void allStatic() {
         CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(2, a.getNumberOfStaticMethods());
+        Assertions.assertEquals(2, a.getNumberOfStaticMethods());
     }
 
     @Test
     public void allDefault() {
         CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(1, a.getNumberOfDefaultMethods());
+        Assertions.assertEquals(1, a.getNumberOfDefaultMethods());
     }
 
     @Test
     public void allPrivate() {
         CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(3, a.getNumberOfPrivateMethods());
+        Assertions.assertEquals(3, a.getNumberOfPrivateMethods());
     }
 
     @Test
     public void allProtected() {
         CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(1, a.getNumberOfProtectedMethods());
+        Assertions.assertEquals(1, a.getNumberOfProtectedMethods());
     }
 
 
     @Test
     public void allSynchronized() {
         CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(1, a.getNumberOfSynchronizedMethods());
+        Assertions.assertEquals(1, a.getNumberOfSynchronizedMethods());
     }
 
     @Test
     public void allAbstract() {
         CKClassResult a = report.get("methods.Methods2");
-        Assert.assertEquals(3, a.getNumberOfMethods());
-        Assert.assertEquals(2, a.getNumberOfAbstractMethods());
+        Assertions.assertEquals(3, a.getNumberOfMethods());
+        Assertions.assertEquals(2, a.getNumberOfAbstractMethods());
     }
 
     @Test
     public void constructors() {
         CKClassResult a = report.get("methods.Methods3");
-        Assert.assertEquals(3, a.getNumberOfMethods());
-        Assert.assertEquals(3, a.getMethods().size());
+        Assertions.assertEquals(3, a.getNumberOfMethods());
+        Assertions.assertEquals(3, a.getMethods().size());
 
         CKMethodResult m1 = a.getMethods().stream().filter(x -> x.getMethodName().equals("Methods3/0")).findFirst().get();
-        Assert.assertTrue(m1.isConstructor());
+        Assertions.assertTrue(m1.isConstructor());
 
         CKMethodResult m2 = a.getMethods().stream().filter(x -> x.getMethodName().equals("Methods3/1[int]")).findFirst().get();
-        Assert.assertTrue(m2.isConstructor());
+        Assertions.assertTrue(m2.isConstructor());
 
         CKMethodResult m3 = a.getMethods().stream().filter(x -> x.getMethodName().equals("a/0")).findFirst().get();
-        Assert.assertFalse(m3.isConstructor());
+        Assertions.assertFalse(m3.isConstructor());
     }
 
     @Test
@@ -87,8 +87,8 @@ public class MethodsTest extends BaseTest {
         CKClassResult a = report.get("methods.StaticInitializer");
 
         Optional<CKMethodResult> init = a.getMethod("(initializer 1)");
-        Assert.assertTrue(init.isPresent());
-        Assert.assertEquals(1, init.get().getLoopQty());
+        Assertions.assertTrue(init.isPresent());
+        Assertions.assertEquals(1, init.get().getLoopQty());
     }
 
     // there can be multiple static initializers in a single class
@@ -98,17 +98,17 @@ public class MethodsTest extends BaseTest {
         CKClassResult a = report.get("methods.StaticInitializer2");
 
         Optional<CKMethodResult> init1 = a.getMethod("(initializer 1)");
-        Assert.assertTrue(init1.isPresent());
-        Assert.assertEquals(1, init1.get().getLoopQty());
+        Assertions.assertTrue(init1.isPresent());
+        Assertions.assertEquals(1, init1.get().getLoopQty());
 
         Optional<CKMethodResult> init2 = a.getMethod("(initializer 2)");
-        Assert.assertTrue(init2.isPresent());
-        Assert.assertEquals(0, init2.get().getLoopQty());
+        Assertions.assertTrue(init2.isPresent());
+        Assertions.assertEquals(0, init2.get().getLoopQty());
     }
 
     @Test
     public void allFinal() {
         CKClassResult a = report.get("methods.Methods");
-        Assert.assertEquals(1, a.getNumberOfFinalMethods());
+        Assertions.assertEquals(1, a.getNumberOfFinalMethods());
     }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/MetricsPerClassesAndInnerClassesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/MetricsPerClassesAndInnerClassesTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class MetricsPerClassesAndInnerClassesTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/innerclasses");
 	}
@@ -18,40 +18,40 @@ public class MetricsPerClassesAndInnerClassesTest extends BaseTest {
 	@Test
 	public void metricsPerClass() {
 
-		Assert.assertEquals(9, report.values().size());
+		Assertions.assertEquals(9, report.values().size());
 
 		CKClassResult a = report.get("innerclasses.MessyClass");
-		Assert.assertEquals(6, a.getNumberOfMethods());
-		Assert.assertEquals("class", a.getType());
+		Assertions.assertEquals(6, a.getNumberOfMethods());
+		Assertions.assertEquals("class", a.getType());
 
 		CKClassResult sc1 = report.get("innerclasses.MessyClass$InnerClass1");
-		Assert.assertEquals(2, sc1.getNumberOfMethods());
-		Assert.assertEquals(2, sc1.getMethods().stream().filter(x -> x.getMethodName().equals("m1/0")).findFirst().get().getMaxNestedBlocks());
-		Assert.assertEquals("innerclass", sc1.getType());
+		Assertions.assertEquals(2, sc1.getNumberOfMethods());
+		Assertions.assertEquals(2, sc1.getMethods().stream().filter(x -> x.getMethodName().equals("m1/0")).findFirst().get().getMaxNestedBlocks());
+		Assertions.assertEquals("innerclass", sc1.getType());
 
 		CKClassResult sc2 = report.get("innerclasses.MessyClass$InnerClass2");
-		Assert.assertEquals(3, sc2.getNumberOfMethods());
-		Assert.assertEquals("innerclass", sc2.getType());
+		Assertions.assertEquals(3, sc2.getNumberOfMethods());
+		Assertions.assertEquals("innerclass", sc2.getType());
 
 		CKClassResult sc3 = report.get("innerclasses.MessyClass$1InnerClass3");
-		Assert.assertEquals(1, sc3.getNumberOfMethods());
-		Assert.assertEquals("innerclass", sc3.getType());
+		Assertions.assertEquals(1, sc3.getNumberOfMethods());
+		Assertions.assertEquals("innerclass", sc3.getType());
 
 		CKClassResult an1 = report.get("innerclasses.MessyClass$Anonymous1");
-		Assert.assertEquals(1, an1.getNumberOfMethods());
-		Assert.assertEquals("anonymous", an1.getType());
+		Assertions.assertEquals(1, an1.getNumberOfMethods());
+		Assertions.assertEquals("anonymous", an1.getType());
 
 		CKClassResult an2 = report.get("innerclasses.MessyClass$Anonymous2");
-		Assert.assertEquals(2, an2.getNumberOfMethods());
-		Assert.assertEquals("anonymous", an2.getType());
+		Assertions.assertEquals(2, an2.getNumberOfMethods());
+		Assertions.assertEquals("anonymous", an2.getType());
 
 
 		CKClassResult ysc2 = report.get("innerclasses.SC2");
-		Assert.assertEquals("class", ysc2.getType());
+		Assertions.assertEquals("class", ysc2.getType());
 		CKClassResult ysc2a = report.get("innerclasses.SC2$Anonymous1");
-		Assert.assertEquals("anonymous", ysc2a.getType());
+		Assertions.assertEquals("anonymous", ysc2a.getType());
 		CKClassResult ysc2x = report.get("innerclasses.SC2$1$1X");
-		Assert.assertEquals("innerclass", ysc2x.getType());
+		Assertions.assertEquals("innerclass", ysc2x.getType());
 
 	}
 

--- a/src/test/java/com/github/mauricioaniche/ck/ModifiersTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/ModifiersTest.java
@@ -1,10 +1,10 @@
 package com.github.mauricioaniche.ck;
 
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jdt.core.dom.Modifier;
 import java.util.Map;
@@ -17,7 +17,7 @@ public class ModifiersTest extends BaseTest {
 	private static Map<String, Integer> modifiersByMethod;
 	private static CKClassResult classResult;
 	
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/modifiers");
 		classResult = report.get("modifiers.ClassWithModifiers");

--- a/src/test/java/com/github/mauricioaniche/ck/NOSITest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NOSITest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NOSITest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/nosi");
 	}
@@ -18,18 +18,18 @@ public class NOSITest extends BaseTest {
 	@Test
 	public void staticInvocations() {
 		CKClassResult a = report.get("nosi.Class2");
-		Assert.assertEquals(1, a.getNosi());
+		Assertions.assertEquals(1, a.getNosi());
 	}
 
 	@Test
 	public void staticInvocationsToMethodsInTheSameClass() {
 		CKClassResult a = report.get("nosi.Class3");
-		Assert.assertEquals(2, a.getNosi());
+		Assertions.assertEquals(2, a.getNosi());
 	}
 
 	@Test
 	public void doesNotUnderstandWhenNotResolvable() {
 		CKClassResult a = report.get("nosi.Class1");
-		Assert.assertEquals(0, a.getNosi());
+		Assertions.assertEquals(0, a.getNosi());
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfAssignmentsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfAssignmentsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfAssignmentsTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/assignments");
 	}
@@ -19,11 +19,11 @@ public class NumberOfAssignmentsTest extends BaseTest {
 	public void count() {
 		CKClassResult a = report.get("assignments.Assignments");
 
-		Assert.assertEquals(8, a.getAssignmentsQty());
+		Assertions.assertEquals(8, a.getAssignmentsQty());
 
-		Assert.assertEquals(5, a.getMethod("m1/0").get().getAssignmentsQty());
-		Assert.assertEquals(3, a.getMethod("m2/0").get().getAssignmentsQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getAssignmentsQty());
+		Assertions.assertEquals(5, a.getMethod("m1/0").get().getAssignmentsQty());
+		Assertions.assertEquals(3, a.getMethod("m2/0").get().getAssignmentsQty());
+		Assertions.assertEquals(0, a.getMethod("m3/0").get().getAssignmentsQty());
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfComparisonsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfComparisonsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfComparisonsTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/comparison");
 	}
@@ -19,12 +19,12 @@ public class NumberOfComparisonsTest extends BaseTest {
 	public void count() {
 		CKClassResult a = report.get("comparison.Comparison");
 
-		Assert.assertEquals(4, a.getComparisonsQty());
+		Assertions.assertEquals(4, a.getComparisonsQty());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getComparisonsQty());
-		Assert.assertEquals(1, a.getMethod("m2/0").get().getComparisonsQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getComparisonsQty());
-		Assert.assertEquals(1, a.getMethod("m4/0").get().getComparisonsQty());
+		Assertions.assertEquals(2, a.getMethod("m1/0").get().getComparisonsQty());
+		Assertions.assertEquals(1, a.getMethod("m2/0").get().getComparisonsQty());
+		Assertions.assertEquals(0, a.getMethod("m3/0").get().getComparisonsQty());
+		Assertions.assertEquals(1, a.getMethod("m4/0").get().getComparisonsQty());
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfInnerClassesLambdasAndAnonymousClassesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfInnerClassesLambdasAndAnonymousClassesTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfInnerClassesLambdasAndAnonymousClassesTest extends BaseTest
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = runDebug(fixturesDir() + "/innerclasses");
 		report = run(fixturesDir() + "/innerclasses");
@@ -20,34 +20,34 @@ public class NumberOfInnerClassesLambdasAndAnonymousClassesTest extends BaseTest
 	public void count() {
 		CKClassResult a = report.get("innerclasses.MessyClass");
 
-		Assert.assertEquals(2, a.getAnonymousClassesQty());
-		Assert.assertEquals(1, a.getLambdasQty());
-		Assert.assertEquals(3, a.getInnerClassesQty());
+		Assertions.assertEquals(2, a.getAnonymousClassesQty());
+		Assertions.assertEquals(1, a.getLambdasQty());
+		Assertions.assertEquals(3, a.getInnerClassesQty());
 
-		Assert.assertEquals(0, a.getMethod("m1/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m1/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m1/0").get().getInnerClassesQty());
+		Assertions.assertEquals(0, a.getMethod("m1/0").get().getAnonymousClassesQty());
+		Assertions.assertEquals(0, a.getMethod("m1/0").get().getLambdasQty());
+		Assertions.assertEquals(0, a.getMethod("m1/0").get().getInnerClassesQty());
 
-		Assert.assertEquals(0, a.getMethod("m2/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m2/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m2/0").get().getInnerClassesQty());
+		Assertions.assertEquals(0, a.getMethod("m2/0").get().getAnonymousClassesQty());
+		Assertions.assertEquals(0, a.getMethod("m2/0").get().getLambdasQty());
+		Assertions.assertEquals(0, a.getMethod("m2/0").get().getInnerClassesQty());
 
-		Assert.assertEquals(1, a.getMethod("m3/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getInnerClassesQty());
+		Assertions.assertEquals(1, a.getMethod("m3/0").get().getAnonymousClassesQty());
+		Assertions.assertEquals(0, a.getMethod("m3/0").get().getLambdasQty());
+		Assertions.assertEquals(0, a.getMethod("m3/0").get().getInnerClassesQty());
 
-		Assert.assertEquals(1, a.getMethod("m4/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m4/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m4/0").get().getInnerClassesQty());
+		Assertions.assertEquals(1, a.getMethod("m4/0").get().getLambdasQty());
+		Assertions.assertEquals(0, a.getMethod("m4/0").get().getAnonymousClassesQty());
+		Assertions.assertEquals(0, a.getMethod("m4/0").get().getInnerClassesQty());
 
 
-		Assert.assertEquals(1, a.getMethod("m5/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m5/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m5/0").get().getInnerClassesQty());
+		Assertions.assertEquals(1, a.getMethod("m5/0").get().getAnonymousClassesQty());
+		Assertions.assertEquals(0, a.getMethod("m5/0").get().getLambdasQty());
+		Assertions.assertEquals(0, a.getMethod("m5/0").get().getInnerClassesQty());
 
-		Assert.assertEquals(1, a.getMethod("m6/0").get().getInnerClassesQty());
-		Assert.assertEquals(0, a.getMethod("m6/0").get().getLambdasQty());
-		Assert.assertEquals(0, a.getMethod("m6/0").get().getAnonymousClassesQty());
+		Assertions.assertEquals(1, a.getMethod("m6/0").get().getInnerClassesQty());
+		Assertions.assertEquals(0, a.getMethod("m6/0").get().getLambdasQty());
+		Assertions.assertEquals(0, a.getMethod("m6/0").get().getAnonymousClassesQty());
 	}
 
 	@Test
@@ -56,24 +56,24 @@ public class NumberOfInnerClassesLambdasAndAnonymousClassesTest extends BaseTest
 		System.out.println(report.keySet());
 		CKClassResult a = report.get("innerclasses.SC2");
 		// the innerclass is inside the anonymous method inside the method (two levels below...), and not the class...
-		Assert.assertEquals(0, a.getInnerClassesQty());
-		Assert.assertEquals(1, a.getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getLambdasQty());
+		Assertions.assertEquals(0, a.getInnerClassesQty());
+		Assertions.assertEquals(1, a.getAnonymousClassesQty());
+		Assertions.assertEquals(0, a.getLambdasQty());
 
-		Assert.assertEquals(1, a.getMethod("m1/0").get().getAnonymousClassesQty());
-		Assert.assertEquals(0, a.getMethod("m1/0").get().getInnerClassesQty());
-		Assert.assertEquals(0, a.getMethod("m1/0").get().getLambdasQty());
+		Assertions.assertEquals(1, a.getMethod("m1/0").get().getAnonymousClassesQty());
+		Assertions.assertEquals(0, a.getMethod("m1/0").get().getInnerClassesQty());
+		Assertions.assertEquals(0, a.getMethod("m1/0").get().getLambdasQty());
 
 		CKClassResult b = report.get("innerclasses.SC2$Anonymous1");
-		Assert.assertEquals(1, b.getMethod("toString/0").get().getInnerClassesQty());
-		Assert.assertEquals(1, b.getInnerClassesQty());
-		Assert.assertEquals(0, b.getLambdasQty());
-		Assert.assertEquals(0, b.getAnonymousClassesQty());
+		Assertions.assertEquals(1, b.getMethod("toString/0").get().getInnerClassesQty());
+		Assertions.assertEquals(1, b.getInnerClassesQty());
+		Assertions.assertEquals(0, b.getLambdasQty());
+		Assertions.assertEquals(0, b.getAnonymousClassesQty());
 
 		CKClassResult sc = report.get("innerclasses.SC2$1$1X");
-		Assert.assertNotNull(sc);
-		Assert.assertEquals(0, sc.getInnerClassesQty());
-		Assert.assertEquals(0, sc.getLambdasQty());
-		Assert.assertEquals(0, sc.getAnonymousClassesQty());
+		Assertions.assertNotNull(sc);
+		Assertions.assertEquals(0, sc.getInnerClassesQty());
+		Assertions.assertEquals(0, sc.getLambdasQty());
+		Assertions.assertEquals(0, sc.getAnonymousClassesQty());
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfLogStatementsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfLogStatementsTest.java
@@ -1,17 +1,17 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NumberOfLogStatementsTest extends BaseTest {
 
     private static Map<String, CKClassResult> report;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         report = run(fixturesDir() + "/logs");
     }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfLoopsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfLoopsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfLoopsTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/loop");
 	}
@@ -19,13 +19,13 @@ public class NumberOfLoopsTest extends BaseTest {
 	public void count() {
 		CKClassResult a = report.get("loop.Loop");
 
-		Assert.assertEquals(5, a.getLoopQty());
+		Assertions.assertEquals(5, a.getLoopQty());
 
-		Assert.assertEquals(1, a.getMethod("m1/0").get().getLoopQty());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getLoopQty());
-		Assert.assertEquals(1, a.getMethod("m3/0").get().getLoopQty());
-		Assert.assertEquals(0, a.getMethod("m4/0").get().getLoopQty());
-		Assert.assertEquals(1, a.getMethod("m5/0").get().getLoopQty());
+		Assertions.assertEquals(1, a.getMethod("m1/0").get().getLoopQty());
+		Assertions.assertEquals(2, a.getMethod("m2/0").get().getLoopQty());
+		Assertions.assertEquals(1, a.getMethod("m3/0").get().getLoopQty());
+		Assertions.assertEquals(0, a.getMethod("m4/0").get().getLoopQty());
+		Assertions.assertEquals(1, a.getMethod("m5/0").get().getLoopQty());
 
 	}
 
@@ -33,12 +33,12 @@ public class NumberOfLoopsTest extends BaseTest {
 	public void infiniteLoops() {
 		CKClassResult a = report.get("loop.Loop2");
 
-		Assert.assertEquals(6, a.getLoopQty());
-		Assert.assertEquals(0, a.getMethod("m0/0").get().getLoopQty());
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getLoopQty());
-		Assert.assertEquals(1, a.getMethod("m2/0").get().getLoopQty());
-		Assert.assertEquals(2, a.getMethod("m3/0").get().getLoopQty());
-		Assert.assertEquals(1, a.getMethod("m4/0").get().getLoopQty());
+		Assertions.assertEquals(6, a.getLoopQty());
+		Assertions.assertEquals(0, a.getMethod("m0/0").get().getLoopQty());
+		Assertions.assertEquals(2, a.getMethod("m1/0").get().getLoopQty());
+		Assertions.assertEquals(1, a.getMethod("m2/0").get().getLoopQty());
+		Assertions.assertEquals(2, a.getMethod("m3/0").get().getLoopQty());
+		Assertions.assertEquals(1, a.getMethod("m4/0").get().getLoopQty());
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfMathOperationsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfMathOperationsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfMathOperationsTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/math");
 	}
@@ -19,11 +19,11 @@ public class NumberOfMathOperationsTest extends BaseTest {
 	public void count() {
 		CKClassResult a = report.get("math.Math");
 
-		Assert.assertEquals(5, a.getMathOperationsQty());
+		Assertions.assertEquals(5, a.getMathOperationsQty());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getMathOperationsQty());
-		Assert.assertEquals(3, a.getMethod("m2/0").get().getMathOperationsQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getMathOperationsQty());
+		Assertions.assertEquals(2, a.getMethod("m1/0").get().getMathOperationsQty());
+		Assertions.assertEquals(3, a.getMethod("m2/0").get().getMathOperationsQty());
+		Assertions.assertEquals(0, a.getMethod("m3/0").get().getMathOperationsQty());
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfMaxNestedBlocksTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfMaxNestedBlocksTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfMaxNestedBlocksTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/nestedblocks");
 	}
@@ -19,72 +19,72 @@ public class NumberOfMaxNestedBlocksTest extends BaseTest {
 	public void count() {
 		CKClassResult a = report.get("nestedblocks.NestedBlocks");
 
-		Assert.assertEquals(5, a.getMaxNestedBlocks());
+		Assertions.assertEquals(5, a.getMaxNestedBlocks());
 
-		Assert.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(2, a.getMethod("m2/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(0, a.getMethod("m3/0").get().getMaxNestedBlocks());
 	}
 
 	@Test
 	public void blocksWithNoClearOpenBracket() {
 		CKClassResult a = report.get("nestedblocks.NestedBlocks2");
 
-		Assert.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(2, a.getMethod("m2/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(0, a.getMethod("m3/0").get().getMaxNestedBlocks());
 
-		Assert.assertEquals(5, a.getMaxNestedBlocks());
+		Assertions.assertEquals(5, a.getMaxNestedBlocks());
 	}
 
 	@Test
 	public void loops() {
 		CKClassResult a = report.get("nestedblocks.NestedBlocks3");
 
-		Assert.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(5, a.getMethod("m1/0").get().getMaxNestedBlocks());
 
-		Assert.assertEquals(5, a.getMaxNestedBlocks());
+		Assertions.assertEquals(5, a.getMaxNestedBlocks());
 	}
 
 	@Test
 	public void switchCases() {
 		CKClassResult a = report.get("nestedblocks.NestedBlocks4");
 
-		Assert.assertEquals(4, a.getMethod("m1/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(4, a.getMethod("m2/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(4, a.getMethod("m1/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(4, a.getMethod("m2/0").get().getMaxNestedBlocks());
 
-		Assert.assertEquals(4, a.getMaxNestedBlocks());
+		Assertions.assertEquals(4, a.getMaxNestedBlocks());
 	}
 
 	@Test
 	public void blocksJustBecause() {
 		CKClassResult a = report.get("nestedblocks.NestedBlocks5");
 
-		Assert.assertEquals(3, a.getMethod("m1/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(3, a.getMethod("m1/0").get().getMaxNestedBlocks());
 
-		Assert.assertEquals(3, a.getMaxNestedBlocks());
+		Assertions.assertEquals(3, a.getMaxNestedBlocks());
 	}
 
 	@Test
 	public void tryCatch() {
 		CKClassResult a = report.get("nestedblocks.NestedBlocks6");
 
-		Assert.assertEquals(3, a.getMethod("m1/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(6, a.getMethod("m2/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(3, a.getMethod("m1/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(6, a.getMethod("m2/0").get().getMaxNestedBlocks());
 
 
-		Assert.assertEquals(6, a.getMaxNestedBlocks());
+		Assertions.assertEquals(6, a.getMaxNestedBlocks());
 	}
 
 	@Test
 	public void useSynchronized() {
 		CKClassResult a = report.get("nestedblocks.NestedBlocks7");
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getMaxNestedBlocks());
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(2, a.getMethod("m1/0").get().getMaxNestedBlocks());
+		Assertions.assertEquals(2, a.getMethod("m1/0").get().getMaxNestedBlocks());
 
 
-		Assert.assertEquals(2, a.getMaxNestedBlocks());
+		Assertions.assertEquals(2, a.getMaxNestedBlocks());
 	}
 
 	// Basic enums do not have nested blocks
@@ -92,7 +92,7 @@ public class NumberOfMaxNestedBlocksTest extends BaseTest {
 	public void enums() {
 		CKClassResult a = report.get("nestedblocks.SimpleEnum");
 
-		Assert.assertEquals(0, a.getMaxNestedBlocks());
+		Assertions.assertEquals(0, a.getMaxNestedBlocks());
 	}
 
 	// based on issue #40
@@ -100,6 +100,6 @@ public class NumberOfMaxNestedBlocksTest extends BaseTest {
 	public void classesWithNoMethods() {
 		CKClassResult a = report.get("nestedblocks.NestedBlocks8");
 
-		Assert.assertEquals(0, a.getMaxNestedBlocks());
+		Assertions.assertEquals(0, a.getMaxNestedBlocks());
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfNumbersTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfNumbersTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfNumbersTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/numbers");
 	}
@@ -19,10 +19,10 @@ public class NumberOfNumbersTest extends BaseTest {
 	public void count() {
 		CKClassResult a = report.get("numbers.Numbers");
 
-		Assert.assertEquals(5, a.getNumbersQty());
+		Assertions.assertEquals(5, a.getNumbersQty());
 
-		Assert.assertEquals(5, a.getMethod("m1/0").get().getNumbersQty());
-		Assert.assertEquals(0, a.getMethod("m2/0").get().getNumbersQty());
+		Assertions.assertEquals(5, a.getMethod("m1/0").get().getNumbersQty());
+		Assertions.assertEquals(0, a.getMethod("m2/0").get().getNumbersQty());
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfReturnsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfReturnsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfReturnsTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/returns");
 	}
@@ -19,12 +19,12 @@ public class NumberOfReturnsTest extends BaseTest {
 	public void count() {
 		CKClassResult a = report.get("returns.Returns");
 
-		Assert.assertEquals(6, a.getReturnQty());
+		Assertions.assertEquals(6, a.getReturnQty());
 
-		Assert.assertEquals(3, a.getMethod("m1/0").get().getReturnQty());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getReturnQty());
-		Assert.assertEquals(1, a.getMethod("m3/0").get().getReturnQty());
-		Assert.assertEquals(0, a.getMethod("m4/0").get().getReturnQty());
+		Assertions.assertEquals(3, a.getMethod("m1/0").get().getReturnQty());
+		Assertions.assertEquals(2, a.getMethod("m2/0").get().getReturnQty());
+		Assertions.assertEquals(1, a.getMethod("m3/0").get().getReturnQty());
+		Assertions.assertEquals(0, a.getMethod("m4/0").get().getReturnQty());
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfStringsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfStringsTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfStringsTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/strings");
 	}
@@ -19,11 +19,11 @@ public class NumberOfStringsTest extends BaseTest {
 	public void count() {
 		CKClassResult a = report.get("strings.Strings");
 
-		Assert.assertEquals(4, a.getStringLiteralsQty());
+		Assertions.assertEquals(4, a.getStringLiteralsQty());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getStringLiteralsQty());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getStringLiteralsQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getStringLiteralsQty());
+		Assertions.assertEquals(2, a.getMethod("m1/0").get().getStringLiteralsQty());
+		Assertions.assertEquals(2, a.getMethod("m2/0").get().getStringLiteralsQty());
+		Assertions.assertEquals(0, a.getMethod("m3/0").get().getStringLiteralsQty());
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfTryCatchesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfTryCatchesTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfTryCatchesTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/trycatch");
 	}
@@ -19,12 +19,12 @@ public class NumberOfTryCatchesTest extends BaseTest {
 	public void count() {
 		CKClassResult a = report.get("trycatch.TryCatch");
 
-		Assert.assertEquals(4, a.getTryCatchQty());
+		Assertions.assertEquals(4, a.getTryCatchQty());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getTryCatchQty());
-		Assert.assertEquals(1, a.getMethod("m2/0").get().getTryCatchQty());
-		Assert.assertEquals(1, a.getMethod("m3/0").get().getTryCatchQty());
-		Assert.assertEquals(0, a.getMethod("m4/0").get().getTryCatchQty());
+		Assertions.assertEquals(2, a.getMethod("m1/0").get().getTryCatchQty());
+		Assertions.assertEquals(1, a.getMethod("m2/0").get().getTryCatchQty());
+		Assertions.assertEquals(1, a.getMethod("m3/0").get().getTryCatchQty());
+		Assertions.assertEquals(0, a.getMethod("m4/0").get().getTryCatchQty());
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfVariablesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfVariablesTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class NumberOfVariablesTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/variables");
 	}
@@ -19,11 +19,11 @@ public class NumberOfVariablesTest extends BaseTest {
 	public void count() {
 		CKClassResult a = report.get("variables.Variables");
 
-		Assert.assertEquals(8, a.getVariablesQty());
+		Assertions.assertEquals(8, a.getVariablesQty());
 
-		Assert.assertEquals(4, a.getMethod("m1/0").get().getVariablesQty());
-		Assert.assertEquals(4, a.getMethod("m2/0").get().getVariablesQty());
-		Assert.assertEquals(0, a.getMethod("m3/0").get().getVariablesQty());
+		Assertions.assertEquals(4, a.getMethod("m1/0").get().getVariablesQty());
+		Assertions.assertEquals(4, a.getMethod("m2/0").get().getVariablesQty());
+		Assertions.assertEquals(0, a.getMethod("m3/0").get().getVariablesQty());
 
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/ParametersTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/ParametersTest.java
@@ -1,17 +1,17 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ParametersTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/parameters");
 	}

--- a/src/test/java/com/github/mauricioaniche/ck/RFCTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/RFCTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class RFCTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/rfc");
 	}
@@ -18,46 +18,46 @@ public class RFCTest extends BaseTest {
 	@Test
 	public void countMethodInvocations() {
 		CKClassResult a = report.get("rfc.GO");
-		Assert.assertEquals(3, a.getRfc());
+		Assertions.assertEquals(3, a.getRfc());
 	}
 
 	@Test
 	public void countSuperInvocations() {
 		CKClassResult a = report.get("rfc.GO3");
-		Assert.assertEquals(2, a.getRfc());
+		Assertions.assertEquals(2, a.getRfc());
 	}
 
 	@Test
 	public void notPossibleToDifferentiateTypesWithStaticAnalysis() {
 		CKClassResult a = report.get("rfc.RFC3");
-		Assert.assertEquals(1, a.getRfc());
+		Assertions.assertEquals(1, a.getRfc());
 	}
 
 	@Test
 	public void doesNotCountConstructorInvocations() {
 		CKClassResult a = report.get("rfc.RFC2");
-		Assert.assertEquals(0, a.getRfc());
+		Assertions.assertEquals(0, a.getRfc());
 	}
 
 	@Test
 	public void methodLevel() {
 		CKClassResult a = report.get("rfc.GO");
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getRfc());
-		Assert.assertEquals(0, a.getMethod("m2/1[int]").get().getRfc());
-		Assert.assertEquals(1, a.getMethod("m3/0").get().getRfc());
+		Assertions.assertEquals(2, a.getMethod("m1/0").get().getRfc());
+		Assertions.assertEquals(0, a.getMethod("m2/1[int]").get().getRfc());
+		Assertions.assertEquals(1, a.getMethod("m3/0").get().getRfc());
 
 	}
 
 	@Test
 	public void noMethodInvocation(){
 		CKClassResult a = report.get("rfc.RFC4");
-		Assert.assertEquals(0, a.getRfc());
+		Assertions.assertEquals(0, a.getRfc());
 	}
 
 	@Test
 	public void functionalInterface(){
 		CKClassResult a = report.get("rfc.RFC5");
-		Assert.assertEquals(3, a.getRfc());
+		Assertions.assertEquals(3, a.getRfc());
 
 	}
 

--- a/src/test/java/com/github/mauricioaniche/ck/VariableOrParameterUsageCountTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/VariableOrParameterUsageCountTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
@@ -10,7 +10,7 @@ public class VariableOrParameterUsageCountTest extends BaseTest{
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/parametercount");
 	}
@@ -19,38 +19,38 @@ public class VariableOrParameterUsageCountTest extends BaseTest{
 	public void justDeclaration() {
 		CKClassResult a = report.get("pcount.A");
 		Map<String, Integer> variablesUsageA = a.getMethod("a/0").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(0), variablesUsageA.get("a"));
-		Assert.assertEquals(Integer.valueOf(0), variablesUsageA.get("b"));
+		Assertions.assertEquals(Integer.valueOf(0), variablesUsageA.get("a"));
+		Assertions.assertEquals(Integer.valueOf(0), variablesUsageA.get("b"));
 	}
 
 	@Test
 	public void normalUse() {
 		CKClassResult a = report.get("pcount.A");
 		Map<String, Integer> variablesUsageA = a.getMethod("b/0").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(4), variablesUsageA.get("a")); // a appears 5 times
-		Assert.assertEquals(Integer.valueOf(2), variablesUsageA.get("b"));
+		Assertions.assertEquals(Integer.valueOf(4), variablesUsageA.get("a")); // a appears 5 times
+		Assertions.assertEquals(Integer.valueOf(2), variablesUsageA.get("b"));
 	}
 
 	@Test
 	public void passingVariableToMethod() {
 		CKClassResult a = report.get("pcount.A");
 		Map<String, Integer> variablesUsageA = a.getMethod("bb/0").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(1), variablesUsageA.get("a"));
+		Assertions.assertEquals(Integer.valueOf(1), variablesUsageA.get("a"));
 	}
 
 	@Test
 	public void methodParameters() {
 		CKClassResult a = report.get("pcount.A");
 		Map<String, Integer> variablesUsageA = a.getMethod("c/1[int]").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(0), variablesUsageA.get("a"));
+		Assertions.assertEquals(Integer.valueOf(0), variablesUsageA.get("a"));
 
 		Map<String, Integer> variablesUsageB = a.getMethod("d/2[int,int]").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(4), variablesUsageB.get("a"));
-		Assert.assertEquals(Integer.valueOf(0), variablesUsageB.get("b"));
+		Assertions.assertEquals(Integer.valueOf(4), variablesUsageB.get("a"));
+		Assertions.assertEquals(Integer.valueOf(0), variablesUsageB.get("b"));
 
 		Map<String, Integer> variablesUsageC = a.getMethod("e/2[pcount.B,int]").get().getVariablesUsage();
-		Assert.assertEquals(Integer.valueOf(2), variablesUsageC.get("a"));
-		Assert.assertEquals(Integer.valueOf(0), variablesUsageC.get("b"));
+		Assertions.assertEquals(Integer.valueOf(2), variablesUsageC.get("a"));
+		Assertions.assertEquals(Integer.valueOf(0), variablesUsageC.get("b"));
 
 	}
 

--- a/src/test/java/com/github/mauricioaniche/ck/WMCTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/WMCTest.java
@@ -1,8 +1,8 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -10,7 +10,7 @@ public class WMCTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/wmc");
 	}
@@ -22,25 +22,25 @@ public class WMCTest extends BaseTest {
 		CKClassResult b = report.get("wmc.CC2");
 		CKClassResult c = report.get("wmc.CC3");
 
-		Assert.assertEquals(4, a.getWmc());
-		Assert.assertEquals(6, b.getWmc());
-		Assert.assertEquals(11, c.getWmc());
+		Assertions.assertEquals(4, a.getWmc());
+		Assertions.assertEquals(6, b.getWmc());
+		Assertions.assertEquals(11, c.getWmc());
 
-		Assert.assertEquals(2, a.getMethod("m1/0").get().getWmc());
-		Assert.assertEquals(2, a.getMethod("m2/0").get().getWmc());
-		Assert.assertEquals(3, b.getMethod("m1/0").get().getWmc());
-		Assert.assertEquals(3, b.getMethod("m2/0").get().getWmc());
-		Assert.assertEquals(11, c.getMethod("m1/0").get().getWmc());
+		Assertions.assertEquals(2, a.getMethod("m1/0").get().getWmc());
+		Assertions.assertEquals(2, a.getMethod("m2/0").get().getWmc());
+		Assertions.assertEquals(3, b.getMethod("m1/0").get().getWmc());
+		Assertions.assertEquals(3, b.getMethod("m2/0").get().getWmc());
+		Assertions.assertEquals(11, c.getMethod("m1/0").get().getWmc());
 	}
 
 	@Test
 	public void doNotCountSubClassesCode() {
 		CKClassResult c = report.get("wmc.CC4");
-		Assert.assertEquals(11, c.getMethod("m1/0").get().getWmc());
-		Assert.assertEquals(11, c.getWmc());
+		Assertions.assertEquals(11, c.getMethod("m1/0").get().getWmc());
+		Assertions.assertEquals(11, c.getWmc());
 
 		CKClassResult c2 = report.get("wmc.CC4$1MethodInner");
-		Assert.assertEquals(3, c2.getMethod("print/0").get().getWmc());
+		Assertions.assertEquals(3, c2.getMethod("print/0").get().getWmc());
 	}
 
 	// related to issue #31
@@ -50,18 +50,18 @@ public class WMCTest extends BaseTest {
 	@Test
 	public void inlineConditions() {
 		CKClassResult c = report.get("wmc.CC6");
-		Assert.assertEquals(7, c.getWmc());
+		Assertions.assertEquals(7, c.getWmc());
 
-		Assert.assertEquals(3, c.getMethod("m1/1[int]").get().getWmc());
-		Assert.assertEquals(4, c.getMethod("m2/1[int]").get().getWmc());
+		Assertions.assertEquals(3, c.getMethod("m1/1[int]").get().getWmc());
+		Assertions.assertEquals(4, c.getMethod("m2/1[int]").get().getWmc());
 	}
 
 	@Test
 	public void straightBooleanComparison() {
 		CKClassResult c = report.get("wmc.CC7");
 
-		Assert.assertEquals(2, c.getMethod("m2/1[boolean]").get().getWmc());
-		Assert.assertEquals(2, c.getMethod("m1/1[boolean]").get().getWmc());
+		Assertions.assertEquals(2, c.getMethod("m2/1[boolean]").get().getWmc());
+		Assertions.assertEquals(2, c.getMethod("m1/1[boolean]").get().getWmc());
 	}
 
 	@Test
@@ -69,15 +69,15 @@ public class WMCTest extends BaseTest {
 
 		CKClassResult c = report.get("wmc.CC8");
 
-		Assert.assertEquals(3, c.getMethod("m0/0").get().getWmc());
-		Assert.assertEquals(6, c.getMethod("m1/0").get().getWmc());
-		Assert.assertEquals(6, c.getMethod("m2/0").get().getWmc());
-		Assert.assertEquals(6, c.getMethod("m3/0").get().getWmc());
-		Assert.assertEquals(2, c.getMethod("m4/0").get().getWmc());
-		Assert.assertEquals(3, c.getMethod("m5/0").get().getWmc());
-		Assert.assertEquals(6, c.getMethod("m6/0").get().getWmc());
+		Assertions.assertEquals(3, c.getMethod("m0/0").get().getWmc());
+		Assertions.assertEquals(6, c.getMethod("m1/0").get().getWmc());
+		Assertions.assertEquals(6, c.getMethod("m2/0").get().getWmc());
+		Assertions.assertEquals(6, c.getMethod("m3/0").get().getWmc());
+		Assertions.assertEquals(2, c.getMethod("m4/0").get().getWmc());
+		Assertions.assertEquals(3, c.getMethod("m5/0").get().getWmc());
+		Assertions.assertEquals(6, c.getMethod("m6/0").get().getWmc());
 
-		Assert.assertEquals(3+6+6+6+2+3+6, c.getWmc());
+		Assertions.assertEquals(3+6+6+6+2+3+6, c.getWmc());
 
 	}
 
@@ -86,26 +86,26 @@ public class WMCTest extends BaseTest {
 
 		CKClassResult c = report.get("wmc.CC9");
 
-		Assert.assertEquals(1, c.getMethod("m0/0").get().getWmc());
-		Assert.assertEquals(2, c.getMethod("m1/0").get().getWmc());
-		Assert.assertEquals(3, c.getMethod("m2/0").get().getWmc());
-		Assert.assertEquals(2, c.getMethod("m3/0").get().getWmc());
-		Assert.assertEquals(4, c.getMethod("m4/0").get().getWmc());
-		Assert.assertEquals(8, c.getMethod("m5/0").get().getWmc());
-		Assert.assertEquals(9, c.getMethod("m6/0").get().getWmc());
-		Assert.assertEquals(5, c.getMethod("m7/0").get().getWmc());
-		Assert.assertEquals(4, c.getMethod("m8/0").get().getWmc());
-		Assert.assertEquals(8, c.getMethod("m9/0").get().getWmc());
+		Assertions.assertEquals(1, c.getMethod("m0/0").get().getWmc());
+		Assertions.assertEquals(2, c.getMethod("m1/0").get().getWmc());
+		Assertions.assertEquals(3, c.getMethod("m2/0").get().getWmc());
+		Assertions.assertEquals(2, c.getMethod("m3/0").get().getWmc());
+		Assertions.assertEquals(4, c.getMethod("m4/0").get().getWmc());
+		Assertions.assertEquals(8, c.getMethod("m5/0").get().getWmc());
+		Assertions.assertEquals(9, c.getMethod("m6/0").get().getWmc());
+		Assertions.assertEquals(5, c.getMethod("m7/0").get().getWmc());
+		Assertions.assertEquals(4, c.getMethod("m8/0").get().getWmc());
+		Assertions.assertEquals(8, c.getMethod("m9/0").get().getWmc());
 
 		// the final 2 is for the two other util methods we have there
-		Assert.assertEquals(1+2+3+2+4+8+9+5+4+8 + 2, c.getWmc());
+		Assertions.assertEquals(1+2+3+2+4+8+9+5+4+8 + 2, c.getWmc());
 
 	}
 
 	@Test
 	public void nested() {
 		CKClassResult c = report.get("wmc.CC10");
-		Assert.assertEquals(9, c.getMethod("m2/0").get().getWmc());
-		Assert.assertEquals(12, c.getMethod("m1/0").get().getWmc());
+		Assertions.assertEquals(9, c.getMethod("m2/0").get().getWmc());
+		Assertions.assertEquals(12, c.getMethod("m1/0").get().getWmc());
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/WordCountsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/WordCountsTest.java
@@ -1,9 +1,9 @@
 package com.github.mauricioaniche.ck;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -14,12 +14,12 @@ public class WordCountsTest extends BaseTest {
 	private CKClassResult w2;
 	private CKClassResult w3;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/wordcounts");
 	}
 	
-	@Before
+	@BeforeEach
 	public void getClasses() {
 		this.w1 = report.get("wordcounts.WordCounts");
 		this.w2 = report.get("wordcounts.WordCounts2");
@@ -28,37 +28,37 @@ public class WordCountsTest extends BaseTest {
 
 	@Test
 	public void count() {
-		Assert.assertEquals(1, w1.getMethod("m1/0").get().getUniqueWordsQty());
-		Assert.assertEquals(7, w1.getMethod("m2/0").get().getUniqueWordsQty());
+		Assertions.assertEquals(1, w1.getMethod("m1/0").get().getUniqueWordsQty());
+		Assertions.assertEquals(7, w1.getMethod("m2/0").get().getUniqueWordsQty());
 	}
 
 	// related to issue #33
 	@Test
 	public void countStaticInitializer() {
-		Assert.assertEquals(1, w2.getMethod("m1/0").get().getUniqueWordsQty());
-		Assert.assertEquals(7, w2.getMethod("m2/0").get().getUniqueWordsQty());
-		Assert.assertEquals(3, w2.getMethod("(initializer 1)").get().getUniqueWordsQty());
+		Assertions.assertEquals(1, w2.getMethod("m1/0").get().getUniqueWordsQty());
+		Assertions.assertEquals(7, w2.getMethod("m2/0").get().getUniqueWordsQty());
+		Assertions.assertEquals(3, w2.getMethod("(initializer 1)").get().getUniqueWordsQty());
 	}
 
 	@Test
 	public void countAtClassLevel() {
-		Assert.assertEquals(10, w1.getUniqueWordsQty());
-		Assert.assertEquals(13, w2.getUniqueWordsQty());
+		Assertions.assertEquals(10, w1.getUniqueWordsQty());
+		Assertions.assertEquals(13, w2.getUniqueWordsQty());
 	}
 
 	// related to issue #34
 	@Test
 	public void subclasses() {
-		Assert.assertEquals(7, w3.getMethod("m2/0").get().getUniqueWordsQty());
-		Assert.assertEquals(10, w3.getUniqueWordsQty());
+		Assertions.assertEquals(7, w3.getMethod("m2/0").get().getUniqueWordsQty());
+		Assertions.assertEquals(10, w3.getUniqueWordsQty());
 
 		// numbers in the subclass
 		CKClassResult subclass = report.get("wordcounts.WordCounts3$1X");
-		Assert.assertEquals(3, subclass.getMethod("xxx/0").get().getUniqueWordsQty());
-		Assert.assertEquals(4, subclass.getUniqueWordsQty());
+		Assertions.assertEquals(3, subclass.getMethod("xxx/0").get().getUniqueWordsQty());
+		Assertions.assertEquals(4, subclass.getUniqueWordsQty());
 
 		CKClassResult subclass2 = report.get("wordcounts.WordCounts3$Y");
-		Assert.assertEquals(2, subclass2.getMethod("yyy/0").get().getUniqueWordsQty());
-		Assert.assertEquals(3, subclass2.getUniqueWordsQty());
+		Assertions.assertEquals(2, subclass2.getMethod("yyy/0").get().getUniqueWordsQty());
+		Assertions.assertEquals(3, subclass2.getUniqueWordsQty());
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/realworld/HugeRealWorldClassTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/realworld/HugeRealWorldClassTest.java
@@ -2,9 +2,9 @@ package com.github.mauricioaniche.ck.realworld;
 
 import com.github.mauricioaniche.ck.BaseTest;
 import com.github.mauricioaniche.ck.CKClassResult;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -12,7 +12,7 @@ public class HugeRealWorldClassTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/real-world-huge-class");
 	}
@@ -22,6 +22,6 @@ public class HugeRealWorldClassTest extends BaseTest {
 	public void hugeClass() {
 		CKClassResult class1 = report.get("com.satoshilabs.trezor.lib.protobuf.TrezorMessage");
 
-		Assert.assertNotNull(class1);
+		Assertions.assertNotNull(class1);
 	}
 }

--- a/src/test/java/com/github/mauricioaniche/ck/realworld/RealWorldClassesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/realworld/RealWorldClassesTest.java
@@ -3,9 +3,9 @@ package com.github.mauricioaniche.ck.realworld;
 import com.github.mauricioaniche.ck.BaseTest;
 import com.github.mauricioaniche.ck.CKClassResult;
 import com.github.mauricioaniche.ck.CKMethodResult;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Optional;
@@ -18,7 +18,7 @@ public class RealWorldClassesTest extends BaseTest {
 
 	private static Map<String, CKClassResult> report;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		report = run(fixturesDir() + "/real-world");
 	}
@@ -47,10 +47,10 @@ public class RealWorldClassesTest extends BaseTest {
 	public void commonsCsvClass2() {
 		CKClassResult ck = report.get("org.apache.commons.csv.CSVFormat");
 
-		Assert.assertEquals(3, ck.getMethod("isLineBreak/1[char]").get().getLoc());
-		Assert.assertEquals(635, ck.getMethod("isLineBreak/1[char]").get().getStartLine());
+		Assertions.assertEquals(3, ck.getMethod("isLineBreak/1[char]").get().getLoc());
+		Assertions.assertEquals(635, ck.getMethod("isLineBreak/1[char]").get().getStartLine());
 
-		Assert.assertEquals(1575, ck.getMethod("withAllowMissingColumnNames/1[boolean]").get().getStartLine());
+		Assertions.assertEquals(1575, ck.getMethod("withAllowMissingColumnNames/1[boolean]").get().getStartLine());
 	}
 
 	// this one always worked
@@ -58,10 +58,10 @@ public class RealWorldClassesTest extends BaseTest {
 	public void xmlInputFactory() {
 
 		CKClassResult a = report.get("javax.xml.stream.XMLInputFactory");
-		Assert.assertEquals(29, a.getNumberOfMethods());
+		Assertions.assertEquals(29, a.getNumberOfMethods());
 
 		Optional<CKMethodResult> m1 = a.getMethod("getXMLReporter/0");
-		Assert.assertTrue(org.eclipse.jdt.core.dom.Modifier.isAbstract(m1.get().getModifiers()));
+		Assertions.assertTrue(org.eclipse.jdt.core.dom.Modifier.isAbstract(m1.get().getModifiers()));
 	}
 
 	// in this one, a method defined inside an anonymous class, instantiated at
@@ -72,7 +72,7 @@ public class RealWorldClassesTest extends BaseTest {
 	public void factoryFinder() {
 
 		CKClassResult a = report.get("javax.xml.ws.spi.FactoryFinder");
-		Assert.assertEquals(3, a.getNumberOfMethods());
+		Assertions.assertEquals(3, a.getNumberOfMethods());
 	}
 
 	// this was crashing, also related to the bug explained in the
@@ -80,7 +80,7 @@ public class RealWorldClassesTest extends BaseTest {
 	@Test
 	public void xmlOutputFactory() {
 		CKClassResult a = report.get("javax.xml.stream.XMLOutputFactory");
-		Assert.assertEquals(14, a.getNumberOfMethods());
+		Assertions.assertEquals(14, a.getNumberOfMethods());
 	}
 
 	// this was crashing, also related to the bug explained in the
@@ -88,10 +88,10 @@ public class RealWorldClassesTest extends BaseTest {
 	@Test
 	public void feature() {
 		CKClassResult a = report.get("com.hry.spring.grpc.stream.Feature");
-		Assert.assertNotNull(a);
+		Assertions.assertNotNull(a);
 
 		Optional<CKMethodResult> m1 = a.getMethod("getNameBytes/0");
-		Assert.assertNotNull(m1);
+		Assertions.assertNotNull(m1);
 	}
 
 	// the number of methods assertion below should be 2.
@@ -102,14 +102,14 @@ public class RealWorldClassesTest extends BaseTest {
 	@Test
 	public void greeterGrpc() {
 		CKClassResult a = report.get("com.hry.spring.grpc.simple.GreeterGrpc");
-		Assert.assertNotNull(a);
+		Assertions.assertNotNull(a);
 		CKClassResult b = report.get("com.hry.spring.grpc.simple.GreeterGrpc$GreeterImplBase");
-		Assert.assertNotNull(b);
+		Assertions.assertNotNull(b);
 
-		Assert.assertEquals(2, b.getNumberOfMethods());
+		Assertions.assertEquals(2, b.getNumberOfMethods());
 
 		CKClassResult c = report.get("com.hry.spring.grpc.simple.GreeterGrpc$GreeterBlockingStub");
-		Assert.assertNotNull(c);
+		Assertions.assertNotNull(c);
 	}
 
 	// this was crashing because of a lambda expression in a field.
@@ -117,27 +117,27 @@ public class RealWorldClassesTest extends BaseTest {
 	@Test
 	public void abstractSimpleHandler() {
 		CKClassResult a = report.get("com.firefly.net.tcp.AbstractSimpleHandler");
-		Assert.assertNotNull(a);
-		Assert.assertEquals(3, a.getNumberOfMethods());
-		Assert.assertEquals(3, a.getNumberOfFields());
+		Assertions.assertNotNull(a);
+		Assertions.assertEquals(3, a.getNumberOfMethods());
+		Assertions.assertEquals(3, a.getNumberOfFields());
 	}
 
 	// one more test case for the same case above. Redundant.
 	@Test
 	public void quotedQualityCSV() {
 		CKClassResult a = report.get("com.firefly.codec.http2.model.QuotedQualityCSV");
-		Assert.assertNotNull(a);
+		Assertions.assertNotNull(a);
 	}
 
 	@Test
 	public void beanificationTestCase() {
-		Assert.assertTrue(report.keySet().contains("org.apache.commons.beanutils2.BeanificationTestCase$1TestIndependenceThread"));
+		Assertions.assertTrue(report.keySet().contains("org.apache.commons.beanutils2.BeanificationTestCase$1TestIndependenceThread"));
 
 		CKClassResult a = report.get("org.apache.commons.beanutils2.BeanificationTestCase$1TestIndependenceThread");
-		Assert.assertNotNull(a);
+		Assertions.assertNotNull(a);
 
-		Assert.assertEquals(3, a.getNumberOfMethods());
-		Assert.assertEquals("innerclass", a.getType());
+		Assertions.assertEquals(3, a.getNumberOfMethods());
+		Assertions.assertEquals("innerclass", a.getType());
 	}
 
 	// this one contains subclasses
@@ -146,19 +146,19 @@ public class RealWorldClassesTest extends BaseTest {
 		CKClassResult class1 = report.get("org.apache.commons.csv.CSVParser2");
 		CKClassResult class2 = report.get("org.apache.commons.csv.CSVParser2$CSVRecordIterator");
 
-		Assert.assertNotNull(class1);
-		Assert.assertNotNull(class2);
+		Assertions.assertNotNull(class1);
+		Assertions.assertNotNull(class2);
 
-		Assert.assertEquals(4, class2.getMethods().size());
+		Assertions.assertEquals(4, class2.getMethods().size());
 
 		Set<String> allMethodsInC2 = class2.getMethods().stream().map(x -> x.getMethodName()).collect(Collectors.toSet());
-		Assert.assertTrue(allMethodsInC2.contains("hasNext/0"));
-		Assert.assertTrue(allMethodsInC2.contains("getNextRecord/0"));
-		Assert.assertTrue(allMethodsInC2.contains("next/0"));
-		Assert.assertTrue(allMethodsInC2.contains("remove/0"));
+		Assertions.assertTrue(allMethodsInC2.contains("hasNext/0"));
+		Assertions.assertTrue(allMethodsInC2.contains("getNextRecord/0"));
+		Assertions.assertTrue(allMethodsInC2.contains("next/0"));
+		Assertions.assertTrue(allMethodsInC2.contains("remove/0"));
 
 		Set<String> allMethodsInC1 = class1.getMethods().stream().map(x -> x.getMethodName()).collect(Collectors.toSet());
-		Assert.assertTrue(allMethodsInC1.contains("createHeaderMap/0"));
+		Assertions.assertTrue(allMethodsInC1.contains("createHeaderMap/0"));
 	}
 
 	// one more long class with static subclasses
@@ -166,24 +166,24 @@ public class RealWorldClassesTest extends BaseTest {
 	@Test
 	public void executorUtils() {
 		CKClassResult class1 = report.get("org.apache.commons.lang.functor.ExecutorUtils");
-		Assert.assertNotNull(class1);
-		Assert.assertFalse(isStatic(class1.getModifiers()));
+		Assertions.assertNotNull(class1);
+		Assertions.assertFalse(isStatic(class1.getModifiers()));
 
 		CKClassResult class2 = report.get("org.apache.commons.lang.functor.ExecutorUtils$ChainedExecutor");
-		Assert.assertNotNull(class2);
-		Assert.assertTrue(isStatic(class2.getModifiers()));
+		Assertions.assertNotNull(class2);
+		Assertions.assertTrue(isStatic(class2.getModifiers()));
 
 		CKClassResult class3 = report.get("org.apache.commons.lang.functor.ExecutorUtils$SwitchExecutor");
-		Assert.assertNotNull(class3);
-		Assert.assertTrue(isStatic(class3.getModifiers()));
+		Assertions.assertNotNull(class3);
+		Assertions.assertTrue(isStatic(class3.getModifiers()));
 
 		CKClassResult class4 = report.get("org.apache.commons.lang.functor.ExecutorUtils$ForExecutor");
-		Assert.assertNotNull(class4);
-		Assert.assertTrue(isStatic(class4.getModifiers()));
+		Assertions.assertNotNull(class4);
+		Assertions.assertTrue(isStatic(class4.getModifiers()));
 
 		CKClassResult class5 = report.get("org.apache.commons.lang.functor.ExecutorUtils$WhileExecutor");
-		Assert.assertNotNull(class5);
-		Assert.assertTrue(isStatic(class5.getModifiers()));
+		Assertions.assertNotNull(class5);
+		Assertions.assertTrue(isStatic(class5.getModifiers()));
 
 	}
 
@@ -195,7 +195,7 @@ public class RealWorldClassesTest extends BaseTest {
 		CKClassResult class1 = report.get("org.asynchttpclient.netty.handler.intercept.Unauthorized401Interceptor");
 
 		CKMethodResult method = class1.getMethod("kerberosChallenge/3[org.asynchttpclient.netty.handler.intercept.Realm,org.asynchttpclient.netty.handler.intercept.Request,org.asynchttpclient.netty.handler.intercept.HttpHeaders]").get();
-		Assert.assertNotNull(method);
+		Assertions.assertNotNull(method);
 	}
 
 	@Test
@@ -203,7 +203,7 @@ public class RealWorldClassesTest extends BaseTest {
 		CKClassResult class1 = report.get("com.ning.http.client.providers.NettyAsyncHttpProvider");
 		System.out.println(class1.getMethods());
 
-		Assert.assertNotNull(class1.getMethod("doConnect/3[com.ning.http.client.providers.Request,com.ning.http.client.providers.AsyncHandler<T>,com.ning.http.client.providers.NettyResponseFuture<T>]"));
+		Assertions.assertNotNull(class1.getMethod("doConnect/3[com.ning.http.client.providers.Request,com.ning.http.client.providers.AsyncHandler<T>,com.ning.http.client.providers.NettyResponseFuture<T>]"));
 	}
 
 	// illustrates the example of https://github.com/mauricioaniche/ck/issues/54

--- a/src/test/java/com/github/mauricioaniche/ck/util/LOCCalculatorTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/util/LOCCalculatorTest.java
@@ -1,7 +1,7 @@
 package com.github.mauricioaniche.ck.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LOCCalculatorTest {
 
@@ -16,7 +16,7 @@ public class LOCCalculatorTest {
 		sb.append("}\r\n");
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
+		Assertions.assertEquals(5, loc);
 	}
 
 	@Test
@@ -30,7 +30,7 @@ public class LOCCalculatorTest {
 
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
+		Assertions.assertEquals(5, loc);
 	}
 
 	@Test
@@ -46,7 +46,7 @@ public class LOCCalculatorTest {
 
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
+		Assertions.assertEquals(5, loc);
 	}
 
 	@Test
@@ -62,7 +62,7 @@ public class LOCCalculatorTest {
 
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
+		Assertions.assertEquals(5, loc);
 	}
 
 	@Test
@@ -82,7 +82,7 @@ public class LOCCalculatorTest {
 
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
+		Assertions.assertEquals(5, loc);
 	}
 
 	@Test
@@ -96,7 +96,7 @@ public class LOCCalculatorTest {
 
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
+		Assertions.assertEquals(5, loc);
 	}
 
 	@Test
@@ -110,7 +110,7 @@ public class LOCCalculatorTest {
 
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
+		Assertions.assertEquals(5, loc);
 	}
 
 	@Test
@@ -125,7 +125,7 @@ public class LOCCalculatorTest {
 
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
+		Assertions.assertEquals(5, loc);
 	}
 
 	@Test
@@ -141,7 +141,7 @@ public class LOCCalculatorTest {
 
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(6, loc);
+		Assertions.assertEquals(6, loc);
 	}
 
 	@Test
@@ -154,7 +154,7 @@ public class LOCCalculatorTest {
 		sb.append("}");
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
+		Assertions.assertEquals(5, loc);
 	}
 
 
@@ -175,7 +175,7 @@ public class LOCCalculatorTest {
 		sb.append("\r\n");
 
 		int loc = LOCCalculator.calculate(sb.toString());
-		Assert.assertEquals(5, loc);
+		Assertions.assertEquals(5, loc);
 	}
 
 

--- a/src/test/java/com/github/mauricioaniche/ck/util/WordCounterTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/util/WordCounterTest.java
@@ -1,7 +1,7 @@
 package com.github.mauricioaniche.ck.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
@@ -12,11 +12,11 @@ public class WordCounterTest {
 		String sourceCode = "a b c d r$ a@ h^";
 
 		Set<String> words = WordCounter.wordsIn(sourceCode);
-		Assert.assertEquals(4, words.size());
-		Assert.assertTrue(words.contains("a"));
-		Assert.assertTrue(words.contains("b"));
-		Assert.assertTrue(words.contains("c"));
-		Assert.assertTrue(words.contains("d"));
+		Assertions.assertEquals(4, words.size());
+		Assertions.assertTrue(words.contains("a"));
+		Assertions.assertTrue(words.contains("b"));
+		Assertions.assertTrue(words.contains("c"));
+		Assertions.assertTrue(words.contains("d"));
 	}
 
 	@Test
@@ -29,11 +29,11 @@ public class WordCounterTest {
 				"\n} }";
 
 		Set<String> words = WordCounter.wordsIn(sourceCode);
-		Assert.assertEquals(4, words.size());
-		Assert.assertTrue(words.contains("Test"));
-		Assert.assertTrue(words.contains("metodo"));
-		Assert.assertTrue(words.contains("taxes"));
-		Assert.assertTrue(words.contains("interests"));
+		Assertions.assertEquals(4, words.size());
+		Assertions.assertTrue(words.contains("Test"));
+		Assertions.assertTrue(words.contains("metodo"));
+		Assertions.assertTrue(words.contains("taxes"));
+		Assertions.assertTrue(words.contains("interests"));
 
 	}
 
@@ -42,11 +42,11 @@ public class WordCounterTest {
 		String sourceCode = "thisIsABigWord another_word_like_this now_weMix";
 		Set<String> words = WordCounter.wordsIn(sourceCode);
 
-		Assert.assertEquals(11, words.size());
+		Assertions.assertEquals(11, words.size());
 
 		String[] expected = new String[] { "A", "Big", "Word", "like", "another", "now", "this", "Is", "word", "Mix", "we"};
 		for (String expectedString : expected) {
-			Assert.assertTrue(words.contains(expectedString));
+			Assertions.assertTrue(words.contains(expectedString));
 		}
 	}
 
@@ -54,7 +54,7 @@ public class WordCounterTest {
 	public void mixOfCamelCase_and_underscore() {
 		Set<String> words = WordCounter.wordsIn("longName_likeThis");
 
-		Assert.assertEquals(4, words.size());
+		Assertions.assertEquals(4, words.size());
 	}
 
 }


### PR DESCRIPTION
**I updated the pom to use Junit 5**

This new version has a readable api and some useful things, such as @DisplayName, to declare more friendly names for test cases.

All old tests are ok with the new version of Junit, I had to change the package of some annotations, but everything works.

[issuecomment](https://github.com/mauricioaniche/ck/pull/56#issuecomment-619568799)