### PR TITLE
Closing the Git resource on IntegrationClass, the opened resource was…

### DIFF
--- a/src/test/java/com/github/mauricioaniche/ck/integration/IntegrationTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/integration/IntegrationTest.java
@@ -55,6 +55,6 @@ public class IntegrationTest {
     }
 
     private void clone(String uri) throws GitAPIException {
-        Git.cloneRepository().setDirectory(new File(tempFolder)).setURI(uri).setCloneAllBranches(true).call();
+    	try (Git git = Git.cloneRepository().setDirectory(new File(tempFolder)).setURI(uri).setCloneAllBranches(true).call()){};
     }
 }


### PR DESCRIPTION
Closing the Git resource on IntegrationClass, the opened resource was causing failure on deleteTempDir() method