### PR TITLE
Updates on Log Statement detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,8 @@ it uses the entire body of the class as metrics.
 The algorithm basically counts the number of words in a method/class, after removing Java keywords. Names are split based on camel case and underline (e.g., longName_likeThis becomes four words).
 See `WordCounter` class for details on the implementation.
 
-- *Number of Log Statements*: Number of log statements in the source code. The counting is based on the following regex:
-`line.matches(".*\\.(info|warn|debug|error)\\(.*") || line.matches(".*log(ger)?\\..*");`.
-See `NumberOfLogStatements.java` for more info.
+- *Number of Log Statements*: Number of log statements in the source code. The counting uses REGEX compatible with SLF4J and Log4J API calls.
+See `NumberOfLogStatements.java` and the test examples (`NumberOfLogStatementsTest` and `fixtures/logs`) for more info.
 
 - *Has Javadoc*: Boolean indicating whether a method has javadoc. (Only at method-level for now) 
 

--- a/fixtures/logs/Log4JHelloWorld.java
+++ b/fixtures/logs/Log4JHelloWorld.java
@@ -1,0 +1,29 @@
+package logs;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Log4JHelloWorld {
+    private static final Logger logger = LogManager.getLogger("HelloWorld");
+    public static void main(String[] args) {
+        logger.info("Hello, World!");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Logging in user " + user.getName() + " with birthday " + user.getBirthdayCalendar());
+        }
+        logger.debug("Logging in user {} with birthday {}", user.getName(), user.getBirthdayCalendar());
+
+        // Java-8 style optimization: no need to explicitly check the log level:
+        // the lambda expression is not evaluated if the TRACE level is not enabled
+        logger.trace("Some long-running operation returned {}", () -> expensiveOperation());
+
+        // pre-Java 8 style optimization: explicitly check the log level
+        // to make sure the expensiveOperation() method is only called if necessary
+        if (logger.isTraceEnabled()) {
+            logger.trace("Some long-running operation returned {}", expensiveOperation());
+        }
+
+        // Fluent API/Builder Pattern
+        logger.atError().withThrowable(exception).log("Unable to process request due to {}", code);
+        logger.atInfo().withMarker(marker).withLocation().withThrowable(exception).log("Login for user {} failed", userId);
+    }
+}

--- a/fixtures/logs/SLF4JExample.java
+++ b/fixtures/logs/SLF4JExample.java
@@ -1,0 +1,24 @@
+package logs;
+
+class SLF4JExample {
+    void foo() {
+        int newT = 15;
+        int oldT = 16;
+
+        // using traditional API
+        logger.debug("Temperature set to {}. Old temperature was {}.", newT, oldT);
+
+        // using fluent API, add arguments one by one and then log message
+        logger.atDebug().addArgument(newT).addArgument(oldT).log("Temperature set to {}. Old temperature was {}.");
+
+        // using fluent API, log message with arguments
+        logger.atDebug().log("Temperature set to {}. Old temperature was {}.", newT, oldT);
+
+        // using fluent API, add one argument and then log message providing one more argument
+        logger.atDebug().addArgument(newT).log("Temperature set to {}. Old temperature was {}.", oldT);
+
+        // using fluent API, add one argument with a Supplier and then log message with one more argument.
+        // Assume the method t16() returns 16.
+        logger.atDebug().addArgument(() -> t16()).log(msg, "Temperature set to {}. Old temperature was {}.", oldT);
+    }
+}

--- a/src/main/java/com/github/mauricioaniche/ck/metric/NumberOfLogStatements.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/NumberOfLogStatements.java
@@ -20,7 +20,7 @@ public class NumberOfLogStatements implements CKASTVisitor, MethodLevelMetric, C
      * 2. It does not support custom log levels as in http://logging.apache.org/log4j/2.x/manual/customloglevels.html
      *
      * @param line The string representation of the given statement
-     * @return <code>true</code> if
+     * @return <code>true</code> if the informed line matches a log statement
      */
     public static boolean isLogStatement(String line) {
         line = line.toLowerCase().trim();

--- a/src/main/java/com/github/mauricioaniche/ck/metric/NumberOfLogStatements.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/NumberOfLogStatements.java
@@ -2,11 +2,30 @@ package com.github.mauricioaniche.ck.metric;
 
 import com.github.mauricioaniche.ck.CKClassResult;
 import com.github.mauricioaniche.ck.CKMethodResult;
-import org.eclipse.jdt.core.dom.*;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.MethodInvocation;
 
 public class NumberOfLogStatements implements CKASTVisitor, MethodLevelMetric, ClassLevelMetric {
 
     private int qty = 0;
+
+    /**
+     * Checks whether an expression represents a log statement based on REGEX.
+     * <p>
+     * Pattern based on log4j API. It also supports builder pattern (see http://logging.apache.org/log4j/2.x/manual/logbuilder.html)
+     * <p>
+     * Limitations:
+     * 1. It does not check for EventLogs as in http://logging.apache.org/log4j/2.x/manual/eventlogging.html
+     * 2. It does not support custom log levels as in http://logging.apache.org/log4j/2.x/manual/customloglevels.html
+     *
+     * @param line The string representation of the given statement
+     * @return <code>true</code> if
+     */
+    public static boolean isLogStatement(String line) {
+        line = line.toLowerCase().trim();
+        return line.matches(".*\\.(at)?(info|warn|debug|error|trace)\\(.*");
+    }
 
     @Override
     public void visit(MethodInvocation node) {
@@ -14,16 +33,10 @@ public class NumberOfLogStatements implements CKASTVisitor, MethodLevelMetric, C
         if (parentNode instanceof ExpressionStatement) {
             ExpressionStatement expr = (ExpressionStatement) parentNode;
             String rawExpr = expr.toString();
-            if (isLogStatement(rawExpr)) {
+            if (NumberOfLogStatements.isLogStatement(rawExpr)) {
                 qty++;
             }
         }
-    }
-
-    private boolean isLogStatement(String line) {
-        line = line.toLowerCase().trim();
-        return (line.matches(".*\\.(info|warn|debug|error)\\(.*")
-                || line.matches(".*log(ger)?\\..*"));
     }
 
     @Override

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfLogStatementsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfLogStatementsTest.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import java.util.Map;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -17,7 +15,7 @@ public class NumberOfLogStatementsTest extends BaseTest {
     }
 
     @Test
-    public void count() {
+    public void testCountLogStatementsFile() {
         CKClassResult a = report.get("logs.LogStatements");
 
         assertEquals(4, a.getNumberOfLogStatements());
@@ -25,5 +23,17 @@ public class NumberOfLogStatementsTest extends BaseTest {
         assertEquals(1, a.getMethod("m1/0").get().getLogStatementsQty());
         assertEquals(0, a.getMethod("m2/0").get().getLogStatementsQty());
         assertEquals(3, a.getMethod("m3/0").get().getLogStatementsQty());
+    }
+
+    @Test
+    public void testCountLog4JHelloWorldFile() {
+        CKClassResult a = report.get("logs.Log4JHelloWorld");
+        assertEquals(7, a.getNumberOfLogStatements());
+    }
+
+    @Test
+    public void testCountSLF4JFile() {
+        CKClassResult a = report.get("logs.SLF4JExample");
+        assertEquals(5, a.getNumberOfLogStatements());
     }
 }


### PR DESCRIPTION
- Added support to fluent api/builder pattern
- Added some examples from Log4J and SLF4J
- Made `islogStatement` static and public since it does not rely on the state of the object and can be used outside CK