### PR TITLE
Fix tests

### DIFF
--- a/fixtures/cbo/Coupling12.java
+++ b/fixtures/cbo/Coupling12.java
@@ -1,0 +1,7 @@
+package cbo;
+
+class Coupling12 {
+    public A sampleMethod() {
+        return SampleClassWithStaticMethod.sampleMethod();
+    }
+}

--- a/fixtures/cbo/Coupling8.java
+++ b/fixtures/cbo/Coupling8.java
@@ -1,10 +1,6 @@
 package cbo;
 
 public class Coupling8 {
-
-  public A sampleMethod() {
-      return SampleClassWithStaticMethod.sampleMethod();
-  }
 	
 	public D m1() {
 		A a = new A();

--- a/src/test/java/com/github/mauricioaniche/ck/CBOTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/CBOTest.java
@@ -117,7 +117,7 @@ public class CBOTest extends BaseTest {
 
 	@Test
 	public void staticMethodCallInReturnStatement() {
-		CKClassResult a = report.get("cbo.Coupling8");
+		CKClassResult a = report.get("cbo.Coupling12");
 		Assertions.assertEquals(3, a.getCbo());
 	}
 


### PR DESCRIPTION
When the pull request #79 was merged, there was a merge conflict in `fixtures/Coupling8.java` (https://github.com/mauricioaniche/ck/commit/0678f81a52afc026f45f372fd81081b9e4396166). On master, `Coupling8.java` had been created, which included a method with a call to a static method in another class. On the other branch, another version of `Coupling8.java` had been added, which was completely different. The way this conflict was resolved was by adding the method from master to the class from that branch. This increased the number of dependencies counted by CBO and broke several tests.

I fixed this problem by reverting the changes to `Coupling8.java`, moving those changes to a new fixture called `Coupling12.java` and using that fixture in the newer tests.

Fixes #88 