### PR TITLE
Fixed unspecified character encoding on Windows

### DIFF
--- a/src/main/java/com/github/mauricioaniche/ck/metric/LCOMNormalized.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/LCOMNormalized.java
@@ -85,7 +85,7 @@ public class LCOMNormalized implements CKASTVisitor, ClassLevelMetric {
 		 * μ(Ai) = number of methods accessing attribute Ai
 		 *  
 		 * This version of computing LCOM is based on Henderson-Sellers definition:
-		 * Henderson-Sellers, Brian, Larry L. Constantine and Ian M. Graham. “Coupling and cohesion (towards a valid metrics suite for object-oriented analysis and design).” Object Oriented Systems 3 (1996): 143-158.
+		 * Henderson-Sellers, Brian, Larry L. Constantine and Ian M. Graham. "Coupling and cohesion (towards a valid metrics suite for object-oriented analysis and design)." Object Oriented Systems 3 (1996): 143-158.
 		 */
 		
 		// formula (13) extracted from https://github.com/cqfn/jpeek/blob/master/papers/sellers96_LCOM2_LCOM3_LCOM5.pdf


### PR DESCRIPTION
As part of the discussion in [!90](https://github.com/mauricioaniche/ck/issues/90) is about, some unspecified character encodings make the build fail on Windows machines. I changed them to the universal double quote character, which makes the build pass on my Windows machine.