### PR TITLE
Specified UTF-8 encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,4 +288,9 @@
 			</build>
 		</profile>
 	</profiles>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
 </project>


### PR DESCRIPTION
Relates to #90, unspecified character encoding would cause failures on windows machines.