### PR TITLE
Hidden files & ignored directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ To use the _latest version_ (which you should), clone the project and generate a
 
 Then, just run:
 ```
-java -jar ck-x.x.x-SNAPSHOT-jar-with-dependencies.jar <project dir> <use jars:true|false> <max files per partition, 0=automatic selection> <variables and fields metrics? True|False> <output dir>
+java -jar ck-x.x.x-SNAPSHOT-jar-with-dependencies.jar <project dir> <use jars:true|false> <max files per partition, 0=automatic selection> <variables and fields metrics? True|False> <output dir> [ignored directories...]
 ```
 
 `Project dir` refers to the directory where CK can find all the source code to be parsed.
@@ -152,6 +152,8 @@ out of memory) you think of tuning it. `Variables and field metrics` indicates t
 you want metrics at variable- and field-levels too. They are highly fine-grained and produce a lot of output;
 you should skip it if you only need metrics at class or method level. Finally, `output dir` refer to the 
 directory where CK will export the csv file with metrics from the analyzed project.
+Optionally, you can specify any number ignored directories, separated by spaces (for example, `build/`).
+By default, `.git` and all other hidden folders are ignored.
 
 The tool will generate three csv files: class, method, and variable levels.
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.github.mauricioaniche</groupId>
 	<artifactId>ck</artifactId>
 	<packaging>jar</packaging>
-	<version>0.6.6-SNAPSHOT</version>
+	<version>0.7.0-SNAPSHOT</version>
 	<name>CK calculator</name>
 	<url>http://www.mauricioaniche.com</url>
 	<description>Java code metrics calculator</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.github.mauricioaniche</groupId>
 	<artifactId>ck</artifactId>
 	<packaging>jar</packaging>
-	<version>0.6.5-SNAPSHOT</version>
+	<version>0.6.6-SNAPSHOT</version>
 	<name>CK calculator</name>
 	<url>http://www.mauricioaniche.com</url>
 	<description>Java code metrics calculator</description>

--- a/src/main/java/com/github/mauricioaniche/ck/Runner.java
+++ b/src/main/java/com/github/mauricioaniche/ck/Runner.java
@@ -1,5 +1,7 @@
 package com.github.mauricioaniche.ck;
 
+import com.github.mauricioaniche.ck.util.FileUtils;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +37,11 @@ public class Runner {
 		if(args.length >= 5)
 			outputDir = args[4];
 
+    // load possible additional ignored directories
+    //noinspection ManualArrayToCollectionCopy
+    for (int i = 5; i < args.length; i++) {
+      FileUtils.IGNORED_DIRECTORIES.add(args[i]);
+    }
 
 		ResultWriter writer = new ResultWriter(outputDir + "class.csv", outputDir + "method.csv", outputDir + "variable.csv", outputDir + "field.csv", variablesAndFields);
 		

--- a/src/main/java/com/github/mauricioaniche/ck/util/FileUtils.java
+++ b/src/main/java/com/github/mauricioaniche/ck/util/FileUtils.java
@@ -1,15 +1,30 @@
 package com.github.mauricioaniche.ck.util;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class FileUtils {
+  public static final List<String> IGNORED_DIRECTORIES = new ArrayList<>();
+
+  //Initialize ignored directories with .git.
+  static {
+    //Use separator so this works on both Windows and Unix-like systems!
+    IGNORED_DIRECTORIES.add(String.format("%c.git%c", File.separatorChar, File.separatorChar));
+  }
+
 	//Get all directories from the directory at the given path.
 	public static String[] getAllDirs(String path) {
 		try {
 			return Files.walk(Paths.get(path))
 					.filter(Files::isDirectory)
-					.filter(x -> !isGitDir(x.toAbsolutePath().toString()))
+          .filter(FileUtils::isHiddenDir)
+					.filter(x -> !isIgnoredDir(x.toAbsolutePath().toString(), IGNORED_DIRECTORIES))
 					.map(x -> x.toAbsolutePath().toString())
 					.toArray(String[]::new);
 		} catch(Exception e) {
@@ -32,7 +47,7 @@ public class FileUtils {
 		try {
 			return Files.walk(Paths.get(path))
 					.filter(Files::isRegularFile)
-					.filter(x -> !isGitDir(x.toAbsolutePath().toString()))
+					.filter(x -> !isIgnoredDir(x.toAbsolutePath().toString(), IGNORED_DIRECTORIES))
 					.filter(x -> x.toAbsolutePath().toString().toLowerCase().endsWith(ending))
 					.map(x -> x.toAbsolutePath().toString())
 					.toArray(String[]::new);
@@ -41,8 +56,23 @@ public class FileUtils {
 		}
 	}
 
-	//Is the given directory a git repository directory?
-	private static boolean isGitDir(String path){
-		return path.contains("/.git/");
-	}
+  // Helper method that falls back to false if there is an exception.
+  public static boolean isHiddenDir(Path path) {
+    try {
+      return Files.isHidden(path);
+    } catch (IOException exception) {
+      exception.printStackTrace();
+      return false;
+    }
+  }
+
+  //Is the directory an ignored directory (e.g. .git)?
+  public static boolean isIgnoredDir(String path, Collection<String> blocked) {
+    for (String ignoredDirectory : blocked) {
+      if (path.contains(ignoredDirectory)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/src/test/java/com/github/mauricioaniche/ck/util/FileUtilsTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/util/FileUtilsTest.java
@@ -1,0 +1,90 @@
+package com.github.mauricioaniche.ck.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+// This file uses OS-specific tests to ensure that the file separator specified in FileUtils works!
+public class FileUtilsTest {
+
+  private static final List<String> IGNORED_CUSTOM = new ArrayList<>();
+
+  static {
+    IGNORED_CUSTOM.addAll(FileUtils.IGNORED_DIRECTORIES);
+    IGNORED_CUSTOM.add(String.format("%cfoo%c", File.separatorChar, File.separatorChar));
+  }
+
+  //Only enabled on Linux/Mac, marking a folder as hidden on Windows programmatically is far from trivial.
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  @Test
+  public void hiddenHidden(@TempDir Path dir) {
+    File file = new File(dir.toFile(), ".hidden/");
+    file.mkdir();
+    Assertions.assertTrue(FileUtils.isHiddenDir(file.toPath()));
+  }
+
+  //Only enabled on Linux/Mac, marking a folder as hidden on Windows programmatically is far from trivial.
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  @Test
+  public void hiddenVisible(@TempDir Path dir) {
+    File file = new File(dir.toFile(), "visible/");
+    file.mkdir();
+    Assertions.assertFalse(FileUtils.isHiddenDir(file.toPath()));
+  }
+
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  @Test
+  public void basicGitTestAllowedLinux() {
+    Assertions.assertFalse(FileUtils.isIgnoredDir("/home/bob/myprojects/", FileUtils.IGNORED_DIRECTORIES));
+  }
+
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  @Test
+  public void basicGitTestDeniedLinux() {
+    Assertions.assertTrue(FileUtils.isIgnoredDir("/home/bob/myprojects/.git/", FileUtils.IGNORED_DIRECTORIES));
+  }
+
+  @EnabledOnOs(OS.WINDOWS)
+  @Test
+  public void basicGitTestAllowedWindows() {
+    Assertions.assertFalse(FileUtils.isIgnoredDir("C:\\Users\\Bob\\myprojects\\", IGNORED_CUSTOM));
+  }
+
+  @EnabledOnOs(OS.WINDOWS)
+  @Test
+  public void basicGitTestDeniedWindows() {
+    Assertions.assertTrue(FileUtils.isIgnoredDir("C:\\Users\\Bob\\myprojects\\.git\\", IGNORED_CUSTOM));
+  }
+
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  @Test
+  public void customTestAllowedLinux() {
+    Assertions.assertFalse(FileUtils.isIgnoredDir("/home/bob/myprojects/bar/", IGNORED_CUSTOM));
+  }
+
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  @Test
+  public void customTestDeniedLinux() {
+    Assertions.assertTrue(FileUtils.isIgnoredDir("/home/bob/myprojects/foo/", IGNORED_CUSTOM));
+  }
+
+  @EnabledOnOs(OS.WINDOWS)
+  @Test
+  public void customTestAllowedWindows() {
+    Assertions.assertFalse(FileUtils.isIgnoredDir("C:\\Users\\Bob\\myprojects\\bar\\", IGNORED_CUSTOM));
+  }
+
+  @EnabledOnOs(OS.WINDOWS)
+  @Test
+  public void customTestDeniedWindows() {
+    Assertions.assertTrue(FileUtils.isIgnoredDir("C:\\Users\\Bob\\myprojects\\foo\\", IGNORED_CUSTOM));
+  }
+
+}


### PR DESCRIPTION
This pull request introduces the fixes proposed in #92. 

More specifically, CK will now ignore all hidden directories (leading `.` on Linux/Mac, some attribute on Windows) when it is walking the project directory. Additionally, the existing `.git` ignore has been ported to work on every operating system.

I added quite a few tests. I can verify that all those on Windows run, but I currently do not have a Linux (or Mac) machine to run the Linux specific tests. I hope that in case GitHub CI can't run these, someone can verify that these indeed pass.

I've taken the liberty to increment the version and change some of the documentation. If there's anything else you want me to do, or change, let me know!