### PR TITLE
Handling the space character in the fixtures folder path

### DIFF
--- a/src/test/java/com/github/mauricioaniche/ck/BaseTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/BaseTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.Callable;
 
@@ -19,7 +21,7 @@ public abstract class BaseTest {
 	protected static String fixturesDir() {
 		try {
 			String cfgFile = new File(BaseTest.class.getResource("/").getPath() + "../../fixtures/").getCanonicalPath();
-			return cfgFile;
+			return URLDecoder.decode(cfgFile, StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
Opa @mauricioaniche, eu clonei o projeto e tentei rodar os testes unitários, porém estava recebendo uma exceção de *java.nio.file.NoSuchFileException*, para a pasta fixtures.

Todos os testes que carrega uma classe da pasta fixtures deu esse erro. Aqui está um pedaço de cima do log dos testes:

```
[INFO] --- maven-surefire-plugin:2.22.2:test (default-test) @ ck ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.github.mauricioaniche.ck.BindingsTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.174 s <<< FAILURE! - in com.github.mauricioaniche.ck.BindingsTest
[ERROR] com.github.mauricioaniche.ck.BindingsTest  Time elapsed: 0.174 s  <<< ERROR!
java.lang.RuntimeException: java.nio.file.NoSuchFileException: C:\Users\Maykon%20Oliveira\Documents\Projects\ck\fixtures\bindings
	at com.github.mauricioaniche.ck.BindingsTest.setUp(BindingsTest.java:15)
Caused by: java.nio.file.NoSuchFileException: C:\Users\Maykon%20Oliveira\Documents\Projects\ck\fixtures\bindings
	at com.github.mauricioaniche.ck.BindingsTest.setUp(BindingsTest.java:15)
[INFO] Running com.github.mauricioaniche.ck.CBOTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0 s <<< FAILURE! - in com.github.mauricioaniche.ck.CBOTest
[ERROR] com.github.mauricioaniche.ck.CBOTest  Time elapsed: 0 s  <<< ERROR!
java.lang.RuntimeException: java.nio.file.NoSuchFileException: C:\Users\Maykon%20Oliveira\Documents\Projects\ck\fixtures\cbo
	at com.github.mauricioaniche.ck.CBOTest.setUp(CBOTest.java:15)
Caused by: java.nio.file.NoSuchFileException: C:\Users\Maykon%20Oliveira\Documents\Projects\ck\fixtures\cbo
	at com.github.mauricioaniche.ck.CBOTest.setUp(CBOTest.java:15)
[INFO] Running com.github.mauricioaniche.ck.ClassTypeTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0 s <<< FAILURE! - in com.github.mauricioaniche.ck.ClassTypeTest
[ERROR] com.github.mauricioaniche.ck.ClassTypeTest  Time elapsed: 0 s  <<< ERROR!
java.lang.RuntimeException: java.nio.file.NoSuchFileException: C:\Users\Maykon%20Oliveira\Documents\Projects\ck\fixtures\class-types
	at com.github.mauricioaniche.ck.ClassTypeTest.setUp(ClassTypeTest.java:19)
Caused by: java.nio.file.NoSuchFileException: C:\Users\Maykon%20Oliveira\Documents\Projects\ck\fixtures\class-types
	at com.github.mauricioaniche.ck.ClassTypeTest.setUp(ClassTypeTest.java:19)
[INFO] Running com.github.mauricioaniche.ck.CouplingTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0 s <<< FAILURE! - in com.github.mauricioaniche.ck.CouplingTest
[ERROR] com.github.mauricioaniche.ck.CouplingTest  Time elapsed: 0 s  <<< ERROR!
java.lang.RuntimeException: java.nio.file.NoSuchFileException: C:\Users\Maykon%20Oliveira\Documents\Projects\ck\fixtures\cbo
	at com.github.mauricioaniche.ck.CouplingTest.setUp(CouplingTest.java:13)
Caused by: java.nio.file.NoSuchFileException: C:\Users\Maykon%20Oliveira\Documents\Projects\ck\fixtures\cbo
	at com.github.mauricioaniche.ck.CouplingTest.setUp(CouplingTest.java:13)
```

Acontece que o caminho absoluto para a pasta, no meu ambiente, contem um espaço no meu nome de usuário do Windows, `C:\Users\Maykon%20Oliveira\`, e esse espaço é codificado para %20. Por conta disso, os arquivos não estavam sendo encontrados.

Eu dei uma pesquisada para saber [como resolver esse problema](https://stackoverflow.com/questions/3263560/sysloader-getresource-problem-in-java), e estou abrindo esse PR para você dar uma olhada e ver se faz sentido. Mas basicamente é só pegar o caminho para a pasta e decodificar em UTF-8.

**É importante verificar se esse problema esta acontecendo com outros usuários do CK, por que bastante gente usa, e ainda não foi relatado esse comportamento.**