### PR TITLE
Improve naming of anonymous classes & fix GitHub CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,30 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.runtime</artifactId>
+			<version>3.26.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.jobs</artifactId>
+			<version>3.13.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.contenttype</artifactId>
+			<version>3.8.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.core.resources</artifactId>
+			<version>3.14.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.eclipse.jdt</groupId>
 			<artifactId>org.eclipse.jdt.core</artifactId>
 			<version>3.26.0</version>

--- a/src/main/java/com/github/mauricioaniche/ck/CKVisitor.java
+++ b/src/main/java/com/github/mauricioaniche/ck/CKVisitor.java
@@ -163,12 +163,18 @@ public class CKVisitor extends ASTVisitor {
 
 		// there might be metrics that use it
 		// (even before an anonymous class is created)
+		String methodName = "";
 		classes.peek().classLevelMetrics.stream().map(metric -> (CKASTVisitor) metric).forEach(ast -> ast.visit(node));
-		if(!classes.peek().methods.isEmpty())
+		if(!classes.peek().methods.isEmpty()) {
 			classes.peek().methods.peek().methodLevelMetrics.stream().map(metric -> (CKASTVisitor) metric).forEach(ast -> ast.visit(node));
+			methodName = '#' + classes.peek().methods.peek().result.getMethodName();
+			if (methodName.contains("/")) {
+				methodName = methodName.substring(0, methodName.indexOf('/'));
+			}
+		}
 
-		// we give the anonymous class a 'class$AnonymousN' name
-		String anonClassName = classes.peek().result.getClassName() + "$Anonymous" + ++anonymousNumber;
+		// we give the anonymous class a 'class#method$AnonymousN' name
+		String anonClassName = classes.peek().result.getClassName() + methodName + "$Anonymous" + ++anonymousNumber;
 		CKClassResult currentClass = new CKClassResult(sourceFilePath, anonClassName, "anonymous", -1);
 		currentClass.setLoc(calculate(node.toString()));
 

--- a/src/test/java/com/github/mauricioaniche/ck/ClassTypeTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/ClassTypeTest.java
@@ -34,10 +34,10 @@ public class ClassTypeTest extends BaseTest {
 		CKClassResult mathOperation = report.get("classtypes.MathOperation");
 		Assertions.assertEquals("interface", mathOperation.getType());
 
-		CKClassResult anon1 = report.get("classtypes.A$Anonymous1");
+		CKClassResult anon1 = report.get("classtypes.A#m2$Anonymous1");
 		Assertions.assertEquals("anonymous", anon1.getType());
 
-		CKClassResult anon2 = report.get("classtypes.A$Anonymous2");
+		CKClassResult anon2 = report.get("classtypes.A#m3$Anonymous2");
 		Assertions.assertEquals("anonymous", anon2.getType());
 
 

--- a/src/test/java/com/github/mauricioaniche/ck/LOCTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/LOCTest.java
@@ -32,7 +32,7 @@ public class LOCTest extends BaseTest {
 		CKClassResult sc2 = report.get("innerclasses.MessyClass$InnerClass2");
 		Assertions.assertEquals(9, sc2.getLoc());
 
-		CKClassResult an1 = report.get("innerclasses.MessyClass$Anonymous1");
+		CKClassResult an1 = report.get("innerclasses.MessyClass#m3$Anonymous1");
 		Assertions.assertEquals(5, an1.getLoc());
 	}
 	

--- a/src/test/java/com/github/mauricioaniche/ck/MetricsPerClassesAndInnerClassesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/MetricsPerClassesAndInnerClassesTest.java
@@ -37,18 +37,18 @@ public class MetricsPerClassesAndInnerClassesTest extends BaseTest {
 		Assertions.assertEquals(1, sc3.getNumberOfMethods());
 		Assertions.assertEquals("innerclass", sc3.getType());
 
-		CKClassResult an1 = report.get("innerclasses.MessyClass$Anonymous1");
+		CKClassResult an1 = report.get("innerclasses.MessyClass#m3$Anonymous1");
 		Assertions.assertEquals(1, an1.getNumberOfMethods());
 		Assertions.assertEquals("anonymous", an1.getType());
 
-		CKClassResult an2 = report.get("innerclasses.MessyClass$Anonymous2");
+		CKClassResult an2 = report.get("innerclasses.MessyClass#m5$Anonymous2");
 		Assertions.assertEquals(2, an2.getNumberOfMethods());
 		Assertions.assertEquals("anonymous", an2.getType());
 
 
 		CKClassResult ysc2 = report.get("innerclasses.SC2");
 		Assertions.assertEquals("class", ysc2.getType());
-		CKClassResult ysc2a = report.get("innerclasses.SC2$Anonymous1");
+		CKClassResult ysc2a = report.get("innerclasses.SC2#m1$Anonymous1");
 		Assertions.assertEquals("anonymous", ysc2a.getType());
 		CKClassResult ysc2x = report.get("innerclasses.SC2$1$1X");
 		Assertions.assertEquals("innerclass", ysc2x.getType());

--- a/src/test/java/com/github/mauricioaniche/ck/NumberOfInnerClassesLambdasAndAnonymousClassesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/NumberOfInnerClassesLambdasAndAnonymousClassesTest.java
@@ -62,7 +62,7 @@ public class NumberOfInnerClassesLambdasAndAnonymousClassesTest extends BaseTest
 		Assertions.assertEquals(0, a.getMethod("m1/0").get().getInnerClassesQty());
 		Assertions.assertEquals(0, a.getMethod("m1/0").get().getLambdasQty());
 
-		CKClassResult b = report.get("innerclasses.SC2$Anonymous1");
+		CKClassResult b = report.get("innerclasses.SC2#m1$Anonymous1");
 		Assertions.assertEquals(1, b.getMethod("toString/0").get().getInnerClassesQty());
 		Assertions.assertEquals(1, b.getInnerClassesQty());
 		Assertions.assertEquals(0, b.getLambdasQty());

--- a/src/test/java/com/github/mauricioaniche/ck/realworld/RealWorldClassesTest.java
+++ b/src/test/java/com/github/mauricioaniche/ck/realworld/RealWorldClassesTest.java
@@ -205,11 +205,10 @@ public class RealWorldClassesTest extends BaseTest {
 	}
 
 	// illustrates the example of https://github.com/mauricioaniche/ck/issues/54
-	// still to be implemented
 	@Test
 	public void hectorPolicyManager_betterNamesForAnonymousClasses() {
 		CKClassResult class1 = report.get("net.retakethe.policyauction.data.impl.HectorPolicyManagerImpl");
-		CKClassResult anonymousClass = report.get("net.retakethe.policyauction.data.impl.HectorPolicyManagerImpl$Anonymous1");
+		CKClassResult anonymousClass = report.get("net.retakethe.policyauction.data.impl.HectorPolicyManagerImpl#getAllPolicies$Anonymous1");
 
 		Assertions.assertNotNull(class1);
 		Assertions.assertNotNull(anonymousClass);


### PR DESCRIPTION
Aims to resolve (part of) #54 and make GitHub CI pass again.

Represents anonymous classes using the `com.example.ClassImpl#method$Anonymous1` format.