### PR TITLE
Fixing the broken build by updating the Java Version.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
 				<version>3.9.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
I have closed the previous PR after realizing an oversight: the work was inadvertently done directly on the master branch instead of a dedicated branch for the build fix. I only realized this when you mentioned in the old PR that there were many non-related commits to the PR.

Well, into the PR itself, initially my efforts were focused on updating dependencies without considering the compatibility with the Java version. This approach did not yield any positive outcomes. It prompted me to adopt a reverse research strategy, where I investigated the release dates of the problematic dependencies. The goal was to identify the timeframe of their release and use that information to deduce the corresponding Java version prevalent at that time.

After several attempts, this approach of aligning the dependencies with the appropriate Java version, based on their release years, proved to be successful. Although the PR is simple, it indeed took me a whole weekend to figure it out.