### PR TITLE
Making the setResult method a default implementation

### DIFF
--- a/src/main/java/com/github/mauricioaniche/ck/metric/ClassLevelMetric.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/ClassLevelMetric.java
@@ -4,9 +4,9 @@ import com.github.mauricioaniche.ck.CKClassResult;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
 public interface ClassLevelMetric {
-	void setResult(CKClassResult result);
+	default void setResult(CKClassResult result){
+	}
 	
 	default void setClassName(String className) {
-
 	}
 }

--- a/src/main/java/com/github/mauricioaniche/ck/metric/NOC.java
+++ b/src/main/java/com/github/mauricioaniche/ck/metric/NOC.java
@@ -34,7 +34,7 @@ public class NOC implements CKASTVisitor, ClassLevelMetric{
 		} else {
 			this.name = node.getName().getFullyQualifiedName();
 			Type type = node.getSuperclassType();
-			
+
 			SimpleType castedFatherType = null;
 			
 			if(node.getSuperclassType() instanceof SimpleType)
@@ -49,10 +49,4 @@ public class NOC implements CKASTVisitor, ClassLevelMetric{
 		}
 		
 	}
-	
-	@Override
-	public void setResult(CKClassResult result) {
-		
-	}
-
 }


### PR DESCRIPTION
Making the setResult method a default implementation to avoid empty methods in classes that do not provide a method body.